### PR TITLE
ci: publish frontend image alongside backend

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push-image:
@@ -19,6 +18,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ${{ github.repository }}
+            context: .
+            file: ./Dockerfile
+          - image: ${{ github.repository }}-frontend
+            context: ./frontend
+            file: ./frontend/Dockerfile
 
     steps:
       - name: Checkout repository
@@ -36,7 +45,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ matrix.image }}
           tags: |
             type=sha,prefix=,suffix=,format=short
             type=ref,event=branch
@@ -46,8 +55,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: ./Dockerfile
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Adds matrix to `publish.yml` so each push builds two images: `ghcr.io/rustyguts/alcoves` (backend, root Dockerfile) and `ghcr.io/rustyguts/alcoves-frontend` (Nuxt SSR, `frontend/Dockerfile`).
- Frontend Dockerfile was added in 5d2df81 but never wired into CI, so deploys past that commit have no frontend image to pull.

## Test plan
- [ ] Workflow run on PR builds both images (push step skipped on PR)
- [ ] After merge, `ghcr.io/rustyguts/alcoves-frontend:<sha>` exists for the merge commit
- [ ] Pull and run frontend image locally, hit `:3000`, confirm Nuxt SSR responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)