### PR TITLE
fix(waveform): revert to industry-standard linear peak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ SvelteKit, Django, Go templ) is collapsed into the `0.0.0` entry.
 
 ## [Unreleased]
 
+### Changed
+
+- **Waveform display reverted to industry-standard linear peak (max
+  absolute sample per window).** The v0.18.0 pipeline — per-window RMS,
+  p99 normalization, and a `[-50dB, 0dB] → [0,1]` curve — pinned most
+  windows near the top of the canvas (the dB mapping inflates a -20 dB
+  signal to ~60% height), so quiet passages no longer read as quiet. The
+  revert matches what Audacity, Adobe Audition/Premiere, DaVinci Resolve,
+  Pro Tools, REAPER, FFmpeg's `showwavespic`, wavesurfer.js / peaks.js,
+  and BBC `audiowaveform` all render by default. Existing waveforms in
+  the cache stay on the old algorithm until each file is re-generated
+  (POST `/api/libraries/:id/files/:fileId/waveform`); the frontend
+  already exposes this via the editor.
+
 ## [0.18.0] — 2026-05-12
 
 ### Added

--- a/backend/internal/services/waveform/worker.go
+++ b/backend/internal/services/waveform/worker.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/hibiken/asynq"
@@ -26,30 +25,6 @@ import (
 
 const defaultPeaksPerSecond = 50
 const sampleRateHz = 16000
-
-// Waveform display tuning. The pipeline is: per-window RMS → per-file
-// normalize against a robust reference (a high quantile, so a single clipped
-// sample doesn't squash the rest of the file) → dB curve mapped onto a fixed
-// visual range. This produces a visually balanced waveform regardless of the
-// source's mastering level.
-const (
-	// Reference quantile of per-window RMS used as the file's "peak" for
-	// normalization. Using p99 instead of max keeps occasional outliers
-	// (a stray clip, a single loud transient) from compressing the rest of
-	// the waveform.
-	normalizationQuantile = 0.99
-
-	// Files whose reference RMS is below this floor are treated as silent
-	// and emitted as all-zero peaks. Otherwise we'd amplify the noise floor
-	// of a truly-silent file all the way to full scale.
-	silenceFloorRMS = 1e-4
-
-	// dB floor for the visual mapping. Values quieter than this map to 0;
-	// 0dB (the file's reference level) maps to 1. -50dB gives ~50dB of
-	// usable visual range, which covers most dialog/music dynamics without
-	// devoting half the canvas to inaudible content.
-	waveformDBFloor = -50.0
-)
 
 type Payload struct {
 	LibraryID string `json:"libraryId"`
@@ -233,6 +208,13 @@ func (h *TaskHandler) extractPCM(ctx context.Context, src, dst string) error {
 	return nil
 }
 
+// computePeaks produces one [0,1] sample per window, where each value is the
+// maximum absolute amplitude in that window — the same convention used by
+// Audacity, Adobe Audition/Premiere, DaVinci Resolve, Pro Tools, REAPER,
+// FFmpeg's showwavespic, wavesurfer.js / peaks.js, and BBC audiowaveform.
+// The frontend renders height = peak × canvas_height directly; no per-file
+// normalization or dB curve runs server-side, so loud files look loud and
+// quiet ones look quiet.
 func (h *TaskHandler) computePeaks(pcmPath string, peaksPerSec int) ([]float64, error) {
 	data, err := os.ReadFile(pcmPath)
 	if err != nil {
@@ -248,81 +230,24 @@ func (h *TaskHandler) computePeaks(pcmPath string, peaksPerSec int) ([]float64, 
 		windowSize = 1
 	}
 
-	numWindows := sampleCount / windowSize
-	rms := make([]float64, 0, numWindows)
+	numPeaks := sampleCount / windowSize
+	peaks := make([]float64, 0, numPeaks)
 
 	for i := 0; i+windowSize <= sampleCount; i += windowSize {
-		var sumSq float64
+		maxAmp := float64(0)
 		for j := 0; j < windowSize; j++ {
 			offset := (i + j) * 4
 			bits := binary.LittleEndian.Uint32(data[offset : offset+4])
 			sample := float64(math.Float32frombits(bits))
-			sumSq += sample * sample
+			abs := math.Abs(sample)
+			if abs > maxAmp {
+				maxAmp = abs
+			}
 		}
-		rms = append(rms, math.Sqrt(sumSq/float64(windowSize)))
+		peaks = append(peaks, math.Min(maxAmp, 1.0))
 	}
 
-	return normalizeAndScale(rms), nil
-}
-
-// normalizeAndScale applies per-file loudness normalization and a dB curve
-// to a slice of per-window RMS values, producing the [0,1] heights the
-// frontend renders. The transform has three stages:
-//
-//  1. Pick a reference loudness as the file's high quantile of RMS (p99 by
-//     default). A single clipped sample no longer dictates the scale.
-//  2. Divide every value by the reference (clamped at the silence floor),
-//     then clamp results to [0,1] — values above the reference (the top 1%)
-//     pin to full scale.
-//  3. Convert to dB and map [waveformDBFloor, 0] → [0, 1]. Values quieter
-//     than the floor map to 0.
-//
-// Files whose reference is below silenceFloorRMS are treated as silent and
-// emit all-zero peaks; otherwise we'd amplify pure noise to full scale.
-func normalizeAndScale(rms []float64) []float64 {
-	if len(rms) == 0 {
-		return []float64{}
-	}
-
-	ref := quantile(rms, normalizationQuantile)
-	if ref < silenceFloorRMS {
-		return make([]float64, len(rms))
-	}
-
-	out := make([]float64, len(rms))
-	const visualSpan = -waveformDBFloor
-	for i, v := range rms {
-		if v <= 0 {
-			continue
-		}
-		norm := v / ref
-		if norm > 1 {
-			norm = 1
-		}
-		db := 20 * math.Log10(norm)
-		if db <= waveformDBFloor {
-			continue
-		}
-		out[i] = (db - waveformDBFloor) / visualSpan
-	}
-	return out
-}
-
-// quantile returns the q-quantile of values using the nearest-rank method.
-// q is clamped to [0,1]. The input is not modified.
-func quantile(values []float64, q float64) float64 {
-	if len(values) == 0 {
-		return 0
-	}
-	if q < 0 {
-		q = 0
-	} else if q > 1 {
-		q = 1
-	}
-	sorted := append([]float64(nil), values...)
-	sort.Float64s(sorted)
-	idx := int(math.Round(q * float64(len(sorted)-1)))
-	return sorted[idx]
+	return peaks, nil
 }
 
 func (h *TaskHandler) storeEmptyWaveform(libraryID, fileID string) {

--- a/backend/internal/services/waveform/worker_test.go
+++ b/backend/internal/services/waveform/worker_test.go
@@ -34,51 +34,50 @@ func fillConst(samples []float32, from, to int, value float32) {
 	}
 }
 
-// TestComputePeaks_UsesRMSNotPeak is the headline regression test for the
-// switch from max-peak to RMS sampling. A sustained mid-amplitude tone is the
-// "louder" window perceptually; a single-sample spike in an otherwise-silent
-// window should NOT outrank it. The previous max-peak implementation reversed
-// this — every spike pegged its window to full-scale and drowned out the
-// real signal.
-func TestComputePeaks_UsesRMSNotPeak(t *testing.T) {
+// TestComputePeaks_MaxAbsoluteSamplePerWindow locks in the industry-standard
+// behavior: each output value is the largest |sample| in its window, on a
+// linear scale, no per-file normalization. This matches what every major
+// audio/video editor and waveform library renders.
+func TestComputePeaks_MaxAbsoluteSamplePerWindow(t *testing.T) {
 	h := &TaskHandler{}
 	const ws = sampleRateHz / defaultPeaksPerSecond
 
-	samples := make([]float32, ws*2)
-	// Window 0: sustained tone at 0.5 (RMS = 0.5).
-	fillConst(samples, 0, ws, 0.5)
-	// Window 1: silent except for a single full-scale spike (RMS ≈ 0.056).
-	samples[ws+10] = 1.0
+	samples := make([]float32, ws*3)
+	fillConst(samples, 0, ws, 0.8)
+	fillConst(samples, ws, ws*2, 0.25)
+	// Single spike in an otherwise-silent window — the peak reflects it.
+	samples[ws*2+5] = 0.6
 
 	peaks, err := h.computePeaks(writePCM(t, samples), defaultPeaksPerSecond)
 	if err != nil {
 		t.Fatalf("computePeaks: %v", err)
 	}
-	if len(peaks) != 2 {
-		t.Fatalf("expected 2 peaks, got %d", len(peaks))
+	if len(peaks) != 3 {
+		t.Fatalf("expected 3 peaks, got %d", len(peaks))
 	}
-	if peaks[0] <= peaks[1] {
-		t.Fatalf("sustained tone (peaks[0]=%v) should be louder than single-spike window (peaks[1]=%v)", peaks[0], peaks[1])
+	if math.Abs(peaks[0]-0.8) > 1e-6 {
+		t.Fatalf("peaks[0] = %v, want 0.8", peaks[0])
 	}
-	// Also nail down the absolute scale: the sustained tone is the file's
-	// reference loudness, so it must pin at full scale.
-	if math.Abs(peaks[0]-1.0) > 1e-9 {
-		t.Fatalf("expected sustained-tone window to normalize to 1.0, got %v", peaks[0])
+	if math.Abs(peaks[1]-0.25) > 1e-6 {
+		t.Fatalf("peaks[1] = %v, want 0.25", peaks[1])
+	}
+	if math.Abs(peaks[2]-0.6) > 1e-6 {
+		t.Fatalf("peaks[2] = %v, want 0.6", peaks[2])
 	}
 }
 
-// TestComputePeaks_PerFileNormalization verifies that two files with the same
-// shape but different absolute volumes produce identical waveforms. This is
-// the property that makes a quiet podcast and a loud song equally readable.
-func TestComputePeaks_PerFileNormalization(t *testing.T) {
+// TestComputePeaks_PreservesAbsoluteLevel verifies that a quieter file
+// produces proportionally smaller peaks — i.e. there is no per-file
+// normalization that would flatten dynamics. A loud file should look loud
+// and a quiet file should look quiet.
+func TestComputePeaks_PreservesAbsoluteLevel(t *testing.T) {
 	h := &TaskHandler{}
 	const ws = sampleRateHz / defaultPeaksPerSecond
 
 	build := func(scale float32) []float32 {
-		s := make([]float32, ws*3)
+		s := make([]float32, ws*2)
 		fillConst(s, 0, ws, 1.0*scale)
 		fillConst(s, ws, ws*2, 0.5*scale)
-		fillConst(s, ws*2, ws*3, 0.25*scale)
 		return s
 	}
 
@@ -86,49 +85,21 @@ func TestComputePeaks_PerFileNormalization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loud: %v", err)
 	}
-	quiet, err := h.computePeaks(writePCM(t, build(0.05)), defaultPeaksPerSecond)
+	quiet, err := h.computePeaks(writePCM(t, build(0.1)), defaultPeaksPerSecond)
 	if err != nil {
 		t.Fatalf("quiet: %v", err)
 	}
-	if len(loud) != len(quiet) {
-		t.Fatalf("length mismatch: loud=%d quiet=%d", len(loud), len(quiet))
+
+	if math.Abs(loud[0]-0.8) > 1e-6 || math.Abs(loud[1]-0.4) > 1e-6 {
+		t.Fatalf("loud peaks not preserved: %v", loud)
 	}
-	for i := range loud {
-		if math.Abs(loud[i]-quiet[i]) > 1e-9 {
-			t.Fatalf("normalization not invariant to scale: loud[%d]=%v quiet[%d]=%v", i, loud[i], i, quiet[i])
-		}
+	if math.Abs(quiet[0]-0.1) > 1e-6 || math.Abs(quiet[1]-0.05) > 1e-6 {
+		t.Fatalf("quiet peaks not preserved: %v", quiet)
 	}
 }
 
-// TestComputePeaks_DBCurveExpandsLowerEnd locks in the dB-mapped visual range.
-// A window at -6dBFS relative to the file reference (half-amplitude RMS) must
-// land near 0.88 — well above its raw value of 0.5 — so visible variation
-// happens in the upper half of the canvas where the eye can resolve it.
-func TestComputePeaks_DBCurveExpandsLowerEnd(t *testing.T) {
-	h := &TaskHandler{}
-	const ws = sampleRateHz / defaultPeaksPerSecond
-
-	samples := make([]float32, ws*2)
-	fillConst(samples, 0, ws, 0.5)        // reference window (0 dBFS relative)
-	fillConst(samples, ws, ws*2, 0.25)    // -6 dBFS relative
-
-	peaks, err := h.computePeaks(writePCM(t, samples), defaultPeaksPerSecond)
-	if err != nil {
-		t.Fatalf("computePeaks: %v", err)
-	}
-	if math.Abs(peaks[0]-1.0) > 1e-9 {
-		t.Fatalf("reference window should map to 1.0, got %v", peaks[0])
-	}
-	// (-6.02 dB - (-50 dB)) / 50 dB = 0.8796...
-	const expected = 0.87959
-	if math.Abs(peaks[1]-expected) > 1e-3 {
-		t.Fatalf("expected -6dB window near %v, got %v", expected, peaks[1])
-	}
-}
-
-// TestComputePeaks_SilentInputProducesZeros confirms we don't amplify the
-// noise floor of a silent file all the way to 1.0. Without the silence-floor
-// guard, dividing 0 by a tiny reference would give NaN or unbounded values.
+// TestComputePeaks_SilentInputProducesZeros — silence stays silent. No
+// noise-floor amplification.
 func TestComputePeaks_SilentInputProducesZeros(t *testing.T) {
 	h := &TaskHandler{}
 	const ws = sampleRateHz / defaultPeaksPerSecond
@@ -148,9 +119,8 @@ func TestComputePeaks_SilentInputProducesZeros(t *testing.T) {
 	}
 }
 
-// TestComputePeaks_PolaritySymmetric verifies that since RMS uses x², a
-// negative-going window and the same window inverted produce identical
-// output (no asymmetry from a missing abs()).
+// TestComputePeaks_PolaritySymmetric — peak uses |sample|, so a signal and
+// its inverse produce identical output.
 func TestComputePeaks_PolaritySymmetric(t *testing.T) {
 	h := &TaskHandler{}
 	const ws = sampleRateHz / defaultPeaksPerSecond
@@ -176,20 +146,22 @@ func TestComputePeaks_PolaritySymmetric(t *testing.T) {
 	}
 }
 
-// TestComputePeaks_OutputBoundedZeroOne is a structural guarantee — the
-// renderer multiplies by canvas height and assumes [0,1]. Out-of-range PCM
-// (sample > 1.0) must clamp.
+// TestComputePeaks_OutputBoundedZeroOne — the renderer multiplies by canvas
+// height and assumes [0,1]. Out-of-range PCM (sample > 1.0) must clamp.
 func TestComputePeaks_OutputBoundedZeroOne(t *testing.T) {
 	h := &TaskHandler{}
 	const ws = sampleRateHz / defaultPeaksPerSecond
 	samples := make([]float32, ws*3)
-	fillConst(samples, 0, ws, 5.0)        // way out of range
+	fillConst(samples, 0, ws, 5.0) // way out of range
 	fillConst(samples, ws, ws*2, 0.5)
 	fillConst(samples, ws*2, ws*3, 0.001) // very quiet
 
 	peaks, err := h.computePeaks(writePCM(t, samples), defaultPeaksPerSecond)
 	if err != nil {
 		t.Fatalf("computePeaks: %v", err)
+	}
+	if peaks[0] != 1.0 {
+		t.Fatalf("expected out-of-range to clamp to 1.0, got %v", peaks[0])
 	}
 	for i, p := range peaks {
 		if p < 0 || p > 1 {
@@ -199,7 +171,7 @@ func TestComputePeaks_OutputBoundedZeroOne(t *testing.T) {
 }
 
 // TestComputePeaks_PartialWindowDropped — a trailing partial window must not
-// produce a spurious peak. (Behavior preserved from the old implementation.)
+// produce a spurious peak.
 func TestComputePeaks_PartialWindowDropped(t *testing.T) {
 	h := &TaskHandler{}
 	const ws = sampleRateHz / defaultPeaksPerSecond
@@ -244,116 +216,4 @@ func TestComputePeaks_RejectsBadPCMLength(t *testing.T) {
 	if _, err := h.computePeaks(path, defaultPeaksPerSecond); err == nil {
 		t.Fatalf("expected error for non-multiple-of-4 PCM, got nil")
 	}
-}
-
-// --- Unit tests for the helpers ---
-
-func TestNormalizeAndScale_EmptyInput(t *testing.T) {
-	out := normalizeAndScale(nil)
-	if len(out) != 0 {
-		t.Fatalf("expected empty output, got len=%d", len(out))
-	}
-}
-
-func TestNormalizeAndScale_SilentBelowFloor(t *testing.T) {
-	// All RMS values are below silenceFloorRMS — should emit zeros instead of
-	// dividing by a tiny reference and amplifying pure noise.
-	in := []float64{1e-6, 5e-7, 0, 1e-8}
-	out := normalizeAndScale(in)
-	if len(out) != len(in) {
-		t.Fatalf("length mismatch: in=%d out=%d", len(in), len(out))
-	}
-	for i, v := range out {
-		if v != 0 {
-			t.Fatalf("expected silence at out[%d], got %v", i, v)
-		}
-	}
-}
-
-func TestNormalizeAndScale_ReferenceMapsToOne(t *testing.T) {
-	// The p99 reference value, normalized, should land at exactly 1.0 (0 dB).
-	out := normalizeAndScale([]float64{0.5})
-	if math.Abs(out[0]-1.0) > 1e-12 {
-		t.Fatalf("reference expected 1.0, got %v", out[0])
-	}
-}
-
-func TestNormalizeAndScale_DBFloorMapsToZero(t *testing.T) {
-	// A value 60 dB below reference (factor 1e-3) is below our -50 dB floor,
-	// so it should clamp to 0 — we don't waste visual range on the inaudible.
-	out := normalizeAndScale([]float64{1.0, 1e-3})
-	if out[0] != 1.0 {
-		t.Fatalf("reference should be 1.0, got %v", out[0])
-	}
-	if out[1] != 0 {
-		t.Fatalf("-60dB value should clamp to 0, got %v", out[1])
-	}
-}
-
-func TestNormalizeAndScale_MonotonicOrdering(t *testing.T) {
-	// Strictly increasing RMS → strictly increasing output (above the floor).
-	in := []float64{0.05, 0.1, 0.2, 0.4, 0.8}
-	out := normalizeAndScale(in)
-	for i := 1; i < len(out); i++ {
-		if out[i] <= out[i-1] {
-			t.Fatalf("monotonicity broken at i=%d: out=%v", i, out)
-		}
-	}
-}
-
-func TestNormalizeAndScale_AboveReferenceClamps(t *testing.T) {
-	// The top 1% of windows can exceed the p99 reference — those must clamp
-	// to 1.0 rather than producing positive dB and overshooting.
-	in := make([]float64, 100)
-	for i := range in {
-		in[i] = 0.5
-	}
-	in[99] = 5.0 // outlier well above reference
-	out := normalizeAndScale(in)
-	if out[99] != 1.0 {
-		t.Fatalf("outlier should clamp to 1.0, got %v", out[99])
-	}
-}
-
-func TestQuantile(t *testing.T) {
-	cases := []struct {
-		name string
-		in   []float64
-		q    float64
-		want float64
-	}{
-		{"empty", nil, 0.5, 0},
-		{"single", []float64{0.7}, 0.99, 0.7},
-		{"median odd", []float64{1, 5, 2, 4, 3}, 0.5, 3},
-		{"min", []float64{1, 5, 2, 4, 3}, 0, 1},
-		{"max", []float64{1, 5, 2, 4, 3}, 1, 5},
-		{"q clamped low", []float64{1, 2, 3}, -0.5, 1},
-		{"q clamped high", []float64{1, 2, 3}, 2.0, 3},
-		// p99 of 100 sorted values [1..100] → idx round(0.99*99)=98 → 99.
-		{"p99", makeRange(1, 100), 0.99, 99},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := quantile(tc.in, tc.q)
-			if got != tc.want {
-				t.Fatalf("quantile(%v, %v) = %v, want %v", tc.in, tc.q, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestQuantile_DoesNotMutateInput(t *testing.T) {
-	in := []float64{3, 1, 2}
-	_ = quantile(in, 0.5)
-	if in[0] != 3 || in[1] != 1 || in[2] != 2 {
-		t.Fatalf("input mutated: %v", in)
-	}
-}
-
-func makeRange(lo, hi int) []float64 {
-	out := make([]float64, 0, hi-lo+1)
-	for i := lo; i <= hi; i++ {
-		out = append(out, float64(i))
-	}
-	return out
 }


### PR DESCRIPTION
## Summary

- Revert `computePeaks` to per-window max-absolute-sample on a linear scale (clamped to [0,1]) — the convention used by Audacity, Adobe Audition/Premiere, DaVinci Resolve, Pro Tools, REAPER, FFmpeg's `showwavespic`, wavesurfer.js / peaks.js, and BBC `audiowaveform`.
- Removes the v0.18.0 RMS → p99-normalize → `[-50dB, 0dB]→[0,1]` pipeline. That dB mapping inflated visuals: a window at -20 dB relative to the file reference rendered at ~60% canvas height, so most clips looked like a wall of mid-height bars and quiet passages no longer read as quiet.
- Tests rewritten to lock in the simpler contract (peak-per-window, polarity-symmetric, clamps at 1.0, silence-stays-silent, partial-window-dropped, pps sizing, bad-PCM error). Removed all `normalizeAndScale` / `quantile` helper tests since the helpers themselves are gone.

The frontend renderer (`useWaveformRenderer.ts:87`) already does `height = peak × canvas_height` linearly, so no frontend change is needed.

**Cache behavior:** waveforms generated under v0.18.0 keep the old algorithm until each file is re-generated via `POST /api/libraries/:id/files/:fileId/waveform` (already wired into the editor's regenerate button).

## Test plan

- [x] `go test ./internal/services/waveform/... -count=1` — 8/8 pass
- [x] `go vet ./internal/services/waveform/...` — clean
- [x] No stragglers reference removed helpers (`normalizeAndScale`, `quantile`, `normalizationQuantile`, `silenceFloorRMS`, `waveformDBFloor`)
- [ ] CI: `go test ./... -race -count=1` (CGO not available locally)
- [ ] Manual: open the editor on a previously-processed file, hit regenerate, confirm dynamics return (quiet sections look quiet, loud sections look loud)
- [ ] Manual: compare a quiet podcast and a loud song — quiet file should render visibly shorter bars, not auto-normalize to full height