### PR TITLE
ci: bump release-please-action to v5 (Node.js 24)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           # Prefer a fine-grained PAT so the tag push from release-please
           # triggers downstream workflows (publish.yml). Falls back to


### PR DESCRIPTION
GitHub is deprecating Node.js 20 actions. `googleapis/release-please-action@v4` runs on Node 20; runners force Node 24 starting June 16th, 2026 and remove Node 20 on September 16th, 2026.

`v5.0.0` is the release that upgrades the action to Node 24 (its only breaking change is the runtime bump). Bumps `@v4` → `@v5` in `release-please.yml`.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/