### PR TITLE
fix: resolve 15 handler bugs from bug sweep

### DIFF
--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -309,7 +309,9 @@ func (h *AuthHandler) UpdateMe(c echo.Context) error {
 	}
 
 	var user models.User
-	h.db.Where("id = ?", userID).First(&user)
+	if err := h.db.Where("id = ?", userID).First(&user).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to reload user")
+	}
 
 	return c.JSON(http.StatusOK, toUserResponse(&user))
 }

--- a/backend/internal/handlers/file.go
+++ b/backend/internal/handlers/file.go
@@ -299,7 +299,9 @@ func (h *FileHandler) Update(c echo.Context) error {
 	}
 
 	var file models.File
-	h.db.Where("id = ? AND library_id = ?", fileID, libraryID).First(&file)
+	if err := h.db.Where("id = ? AND library_id = ?", fileID, libraryID).First(&file).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch updated file")
+	}
 
 	return c.JSON(http.StatusOK, h.fileToJSONWithLookup(&file))
 }
@@ -311,7 +313,10 @@ type deleteFileRequest struct {
 func (h *FileHandler) Delete(c echo.Context) error {
 	libraryID := c.Param("id")
 	fileID := c.Param("fileId")
-	libUUID, _ := uuid.Parse(libraryID)
+	libUUID, parseErr := uuid.Parse(libraryID)
+	if parseErr != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid library ID")
+	}
 	actorID := middleware.GetUserID(c)
 
 	now := time.Now()

--- a/backend/internal/handlers/invite.go
+++ b/backend/internal/handlers/invite.go
@@ -125,10 +125,15 @@ func (h *InviteHandler) Accept(c echo.Context) error {
 	result, err := invites.Redeem(h.db, invite, userID)
 	if err != nil {
 		if errors.Is(err, invites.ErrAlreadyMember) {
-			return c.JSON(http.StatusOK, map[string]interface{}{
-				"libraryId": invite.LibraryID.String(),
-				"role":      "owner",
-			})
+			var lib models.Library
+			if dbErr := h.db.Select("owner_id").Where("id = ?", invite.LibraryID).First(&lib).Error; dbErr == nil && lib.OwnerID == userID {
+				return c.JSON(http.StatusOK, map[string]interface{}{"libraryId": invite.LibraryID.String(), "role": "owner"})
+			}
+			var member models.LibraryMember
+			if dbErr := h.db.Where("library_id = ? AND user_id = ?", invite.LibraryID, userID).First(&member).Error; dbErr == nil {
+				return c.JSON(http.StatusOK, map[string]interface{}{"libraryId": invite.LibraryID.String(), "role": member.Role})
+			}
+			return c.JSON(http.StatusOK, map[string]interface{}{"libraryId": invite.LibraryID.String(), "role": "viewer"})
 		}
 		if errors.Is(err, invites.ErrExhausted) {
 			return echo.NewHTTPError(http.StatusGone, "Invite has no remaining uses")

--- a/backend/internal/handlers/library.go
+++ b/backend/internal/handlers/library.go
@@ -259,7 +259,9 @@ func (h *LibraryHandler) Update(c echo.Context) error {
 	}
 
 	var library models.Library
-	h.db.Where("id = ?", libraryID).First(&library)
+	if err := h.db.Where("id = ?", libraryID).First(&library).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to reload library")
+	}
 
 	return c.JSON(http.StatusOK, toLibraryResponse(&library, la))
 }

--- a/backend/internal/handlers/member.go
+++ b/backend/internal/handlers/member.go
@@ -58,9 +58,13 @@ func (h *MemberHandler) ListUsers(c echo.Context) error {
 
 	// Get owner
 	var library models.Library
-	h.db.Select("owner_id").Where("id = ?", libraryID).First(&library)
+	if err := h.db.Select("owner_id").Where("id = ?", libraryID).First(&library).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to load library")
+	}
 	var owner models.User
-	h.db.Select("id, email, display_name, avatar_url").Where("id = ?", library.OwnerID).First(&owner)
+	if err := h.db.Select("id, email, display_name, avatar_url").Where("id = ?", library.OwnerID).First(&owner).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to load library owner")
+	}
 
 	// Build member list with owner first
 	memberList := []map[string]interface{}{

--- a/backend/internal/handlers/moment.go
+++ b/backend/internal/handlers/moment.go
@@ -440,11 +440,13 @@ func (h *MomentHandler) Export(c echo.Context) error {
 	queued := "queued"
 	zero := 0
 	now := time.Now()
-	h.db.Model(&models.Moment{}).Where("id = ?", moment.ID).Updates(map[string]interface{}{
+	if err := h.db.Model(&models.Moment{}).Where("id = ?", moment.ID).Updates(map[string]interface{}{
 		"export_status":   &queued,
 		"export_progress": &zero,
 		"updated_at":      now,
-	})
+	}).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update export status")
+	}
 
 	if h.momentExport != nil {
 		if err := h.momentExport.Enqueue(

--- a/backend/internal/handlers/people.go
+++ b/backend/internal/handlers/people.go
@@ -100,7 +100,9 @@ func (h *PeopleHandler) Update(c echo.Context) error {
 	}
 
 	var person models.Person
-	h.db.Where("id = ?", personID).First(&person)
+	if err := h.db.Where("id = ?", personID).First(&person).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch updated person")
+	}
 
 	return c.JSON(http.StatusOK, toPersonResponse(&person))
 }
@@ -212,33 +214,52 @@ func (h *PeopleHandler) SplitFace(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "Face not found")
 	}
 
-	// Create a new person for this face
-	newPerson := models.Person{
-		LibraryID:            uuid.MustParse(libraryID),
-		CoverFaceDetectionID: &face.ID,
-		FaceCount:            1,
-	}
-	h.db.Create(&newPerson)
-
-	// Move face to new person
-	h.db.Model(&face).Update("person_id", newPerson.ID)
-
-	// Update old person's face count
-	h.db.Model(&models.Person{}).Where("id = ?", personID).
-		Update("face_count", gorm.Expr("face_count - 1"))
-
-	// If old person's cover was this face, clear it
-	var oldPerson models.Person
-	h.db.Where("id = ?", personID).First(&oldPerson)
-	if oldPerson.CoverFaceDetectionID != nil && *oldPerson.CoverFaceDetectionID == face.ID {
-		// Set to another face or nil
-		var anotherFace models.FaceDetection
-		if err := h.db.Where("person_id = ? AND id != ?", personID, faceID).
-			Order("confidence DESC").First(&anotherFace).Error; err == nil {
-			h.db.Model(&oldPerson).Update("cover_face_detection_id", anotherFace.ID)
-		} else {
-			h.db.Model(&oldPerson).Update("cover_face_detection_id", nil)
+	var newPerson models.Person
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		// Create a new person for this face
+		newPerson = models.Person{
+			LibraryID:            uuid.MustParse(libraryID),
+			CoverFaceDetectionID: &face.ID,
+			FaceCount:            1,
 		}
+		if err := tx.Create(&newPerson).Error; err != nil {
+			return err
+		}
+
+		// Move face to new person
+		if err := tx.Model(&face).Update("person_id", newPerson.ID).Error; err != nil {
+			return err
+		}
+
+		// Update old person's face count
+		if err := tx.Model(&models.Person{}).Where("id = ?", personID).
+			Update("face_count", gorm.Expr("face_count - 1")).Error; err != nil {
+			return err
+		}
+
+		// If old person's cover was this face, clear it
+		var oldPerson models.Person
+		if err := tx.Where("id = ?", personID).First(&oldPerson).Error; err != nil {
+			return err
+		}
+		if oldPerson.CoverFaceDetectionID != nil && *oldPerson.CoverFaceDetectionID == face.ID {
+			// Set to another face or nil
+			var anotherFace models.FaceDetection
+			if err := tx.Where("person_id = ? AND id != ?", personID, faceID).
+				Order("confidence DESC").First(&anotherFace).Error; err == nil {
+				if err := tx.Model(&oldPerson).Update("cover_face_detection_id", anotherFace.ID).Error; err != nil {
+					return err
+				}
+			} else {
+				if err := tx.Model(&oldPerson).Update("cover_face_detection_id", nil).Error; err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to split face")
 	}
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
@@ -272,34 +293,56 @@ func (h *PeopleHandler) Merge(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "One or more persons not found")
 	}
 
-	// Move all faces from sources to target
-	h.db.Model(&models.FaceDetection{}).
-		Where("person_id IN ?", sourceIDs).
-		Update("person_id", targetID)
-
-	// Update target face count
-	var totalFaces int64
-	h.db.Model(&models.FaceDetection{}).Where("person_id = ?", targetID).Count(&totalFaces)
-	h.db.Model(&models.Person{}).Where("id = ?", targetID).Update("face_count", totalFaces)
-
-	// Preserve name from sources if target has none
 	var target models.Person
-	h.db.Where("id = ?", targetID).First(&target)
-	if target.Name == nil {
-		for _, sid := range sourceIDs {
-			var source models.Person
-			h.db.Where("id = ?", sid).First(&source)
-			if source.Name != nil {
-				h.db.Model(&target).Update("name", *source.Name)
-				break
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		// Move all faces from sources to target
+		if err := tx.Model(&models.FaceDetection{}).
+			Where("person_id IN ?", sourceIDs).
+			Update("person_id", targetID).Error; err != nil {
+			return err
+		}
+
+		// Update target face count
+		var totalFaces int64
+		if err := tx.Model(&models.FaceDetection{}).Where("person_id = ?", targetID).Count(&totalFaces).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&models.Person{}).Where("id = ?", targetID).Update("face_count", totalFaces).Error; err != nil {
+			return err
+		}
+
+		// Preserve name from sources if target has none
+		if err := tx.Where("id = ?", targetID).First(&target).Error; err != nil {
+			return err
+		}
+		if target.Name == nil {
+			for _, sid := range sourceIDs {
+				var source models.Person
+				if err := tx.Where("id = ?", sid).First(&source).Error; err != nil {
+					return err
+				}
+				if source.Name != nil {
+					if err := tx.Model(&target).Update("name", *source.Name).Error; err != nil {
+						return err
+					}
+					break
+				}
 			}
 		}
+
+		// Delete source persons
+		if err := tx.Where("id IN ?", sourceIDs).Delete(&models.Person{}).Error; err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to merge persons")
 	}
 
-	// Delete source persons
-	h.db.Where("id IN ?", sourceIDs).Delete(&models.Person{})
-
-	h.db.Where("id = ?", targetID).First(&target)
+	if err := h.db.Where("id = ?", targetID).First(&target).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch merged person")
+	}
 	return c.JSON(http.StatusOK, toPersonResponse(&target))
 }
 

--- a/backend/internal/handlers/search.go
+++ b/backend/internal/handlers/search.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -59,7 +60,7 @@ func (h *SearchHandler) Search(c echo.Context) error {
 
 	// Search files across accessible libraries (by filename)
 	var fileResults []searchResult
-	h.db.Raw(`
+	if err := h.db.Raw(`
 		SELECT f.id, f.library_id, l.name as library_name, f.parent_folder_id,
 		       f.name, 'file' as kind, f.mime_type, f.size, f.thumbnail_file_id,
 		       to_char(f.updated_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as updated_at
@@ -72,11 +73,13 @@ func (h *SearchHandler) Search(c echo.Context) error {
 		  AND f.name ILIKE ?
 		ORDER BY f.name ASC
 		LIMIT 50
-	`, userID, userID, searchPattern).Scan(&fileResults)
+	`, userID, userID, searchPattern).Scan(&fileResults).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Search failed")
+	}
 
 	// Search folders across accessible libraries
 	var folderResults []searchResult
-	h.db.Raw(`
+	if err := h.db.Raw(`
 		SELECT fo.id, fo.library_id, l.name as library_name, fo.parent_folder_id,
 		       fo.name, 'folder' as kind, NULL as mime_type, NULL as size,
 		       to_char(fo.updated_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') as updated_at
@@ -88,7 +91,9 @@ func (h *SearchHandler) Search(c echo.Context) error {
 		  AND fo.name ILIKE ?
 		ORDER BY fo.name ASC
 		LIMIT 50
-	`, userID, userID, searchPattern).Scan(&folderResults)
+	`, userID, userID, searchPattern).Scan(&folderResults).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Search failed")
+	}
 
 	// Search files by detected object labels
 	type objectMatch struct {
@@ -105,7 +110,7 @@ func (h *SearchHandler) Search(c echo.Context) error {
 		MatchedLabel    string  `gorm:"column:matched_label"`
 	}
 	var objectResults []objectMatch
-	h.db.Raw(`
+	if err := h.db.Raw(`
 		SELECT DISTINCT ON (f.id)
 		       f.id, f.library_id, l.name as library_name, f.parent_folder_id,
 		       f.name, 'file' as kind, f.mime_type, f.size, f.thumbnail_file_id,
@@ -120,7 +125,9 @@ func (h *SearchHandler) Search(c echo.Context) error {
 		  AND od.label ILIKE ?
 		ORDER BY f.id, od.confidence DESC
 		LIMIT 50
-	`, userID, userID, searchPattern).Scan(&objectResults)
+	`, userID, userID, searchPattern).Scan(&objectResults).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Search failed")
+	}
 
 	// Collect all matched labels per file (a file may match multiple labels)
 	fileLabels := map[string][]string{}
@@ -135,14 +142,17 @@ func (h *SearchHandler) Search(c echo.Context) error {
 			Label  string `gorm:"column:label"`
 		}
 		var allLabels []labelRow
-		h.db.Raw(`
+		if err := h.db.Raw(`
 			SELECT DISTINCT file_id, label
 			FROM object_detections
 			WHERE file_id IN ?
 			  AND label ILIKE ?
-		`, fileIDs, searchPattern).Scan(&allLabels)
-		for _, row := range allLabels {
-			fileLabels[row.FileID] = append(fileLabels[row.FileID], row.Label)
+		`, fileIDs, searchPattern).Scan(&allLabels).Error; err != nil {
+			log.Printf("search: failed to fetch matched labels: %v", err)
+		} else {
+			for _, row := range allLabels {
+				fileLabels[row.FileID] = append(fileLabels[row.FileID], row.Label)
+			}
 		}
 	}
 

--- a/backend/internal/handlers/tag.go
+++ b/backend/internal/handlers/tag.go
@@ -179,15 +179,37 @@ func (h *TagHandler) SyncFileTags(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "File not found")
 	}
 
-	// Delete existing tags
-	h.db.Where("file_id = ?", fileID).Delete(&models.FileTag{})
+	parsedFileID, err := uuid.Parse(fileID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid file ID")
+	}
 
-	// Insert new tags
+	// Parse all tag IDs up front so we can fail fast before touching the DB.
+	parsedTagIDs := make([]uuid.UUID, 0, len(req.TagIDs))
 	for _, tagID := range req.TagIDs {
-		h.db.Create(&models.FileTag{
-			FileID: uuid.MustParse(fileID),
-			TagID:  uuid.MustParse(tagID),
-		})
+		tid, err := uuid.Parse(tagID)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "Invalid tag ID: "+tagID)
+		}
+		parsedTagIDs = append(parsedTagIDs, tid)
+	}
+
+	// Delete + insert atomically so a failed insert never leaves tags half-written.
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("file_id = ?", parsedFileID).Delete(&models.FileTag{}).Error; err != nil {
+			return err
+		}
+		for _, tid := range parsedTagIDs {
+			if err := tx.Create(&models.FileTag{
+				FileID: parsedFileID,
+				TagID:  tid,
+			}).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to sync tags")
 	}
 
 	// Return updated tags
@@ -219,13 +241,37 @@ func (h *TagHandler) SyncFolderTags(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "Folder not found")
 	}
 
-	h.db.Where("folder_id = ?", folderID).Delete(&models.FolderTag{})
+	parsedFolderID, err := uuid.Parse(folderID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid folder ID")
+	}
 
+	// Parse all tag IDs up front so we can fail fast before touching the DB.
+	parsedTagIDs := make([]uuid.UUID, 0, len(req.TagIDs))
 	for _, tagID := range req.TagIDs {
-		h.db.Create(&models.FolderTag{
-			FolderID: uuid.MustParse(folderID),
-			TagID:    uuid.MustParse(tagID),
-		})
+		tid, err := uuid.Parse(tagID)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "Invalid tag ID: "+tagID)
+		}
+		parsedTagIDs = append(parsedTagIDs, tid)
+	}
+
+	// Delete + insert atomically so a failed insert never leaves tags half-written.
+	if err := h.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("folder_id = ?", parsedFolderID).Delete(&models.FolderTag{}).Error; err != nil {
+			return err
+		}
+		for _, tid := range parsedTagIDs {
+			if err := tx.Create(&models.FolderTag{
+				FolderID: parsedFolderID,
+				TagID:    tid,
+			}).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to sync tags")
 	}
 
 	var tags []models.Tag

--- a/frontend/app/composables/useNotificationsSocket.ts
+++ b/frontend/app/composables/useNotificationsSocket.ts
@@ -7,6 +7,8 @@ interface SocketState {
   reconnectAttempt: number;
   closed: boolean;
   pollFallback: ReturnType<typeof setInterval> | null;
+  heartbeatTimer: ReturnType<typeof setInterval> | null;
+  lastMessageAt: number;
 }
 
 interface UseNotificationsSocketReturn {
@@ -31,13 +33,12 @@ export function useNotificationsSocket(): UseNotificationsSocketReturn {
     reconnectAttempt: 0,
     closed: false,
     pollFallback: null,
+    heartbeatTimer: null,
+    lastMessageAt: 0,
   }));
   const connected = useState<boolean>("notifications:connected", () => false);
   const subscribedRooms = useState<Set<string>>("notifications:rooms", () => new Set());
   const handlers = useState<ActivityHandler[]>("notifications:handlers", () => []);
-  let lastMessageAt = Date.now();
-  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-
   function wsUrl(): string {
     if (!import.meta.client) return "";
     const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
@@ -46,10 +47,10 @@ export function useNotificationsSocket(): UseNotificationsSocketReturn {
   }
 
   function startHeartbeat() {
-    if (heartbeatTimer) clearInterval(heartbeatTimer);
-    heartbeatTimer = setInterval(() => {
+    if (state.value.heartbeatTimer) clearInterval(state.value.heartbeatTimer);
+    state.value.heartbeatTimer = setInterval(() => {
       if (!state.value.ws) return;
-      if (Date.now() - lastMessageAt > HEARTBEAT_TIMEOUT_MS) {
+      if (performance.now() - state.value.lastMessageAt > HEARTBEAT_TIMEOUT_MS) {
         // Force-close; onclose triggers reconnect.
         try {
           state.value.ws.close();
@@ -59,9 +60,9 @@ export function useNotificationsSocket(): UseNotificationsSocketReturn {
   }
 
   function stopHeartbeat() {
-    if (heartbeatTimer) {
-      clearInterval(heartbeatTimer);
-      heartbeatTimer = null;
+    if (state.value.heartbeatTimer) {
+      clearInterval(state.value.heartbeatTimer);
+      state.value.heartbeatTimer = null;
     }
   }
 
@@ -102,7 +103,7 @@ export function useNotificationsSocket(): UseNotificationsSocketReturn {
     ws.addEventListener("open", () => {
       connected.value = true;
       state.value.reconnectAttempt = 0;
-      lastMessageAt = Date.now();
+      state.value.lastMessageAt = performance.now();
       // Re-subscribe to all known library rooms.
       for (const room of subscribedRooms.value) {
         ws.send(JSON.stringify({ type: "subscribe", room }));
@@ -114,7 +115,7 @@ export function useNotificationsSocket(): UseNotificationsSocketReturn {
       startHeartbeat();
     });
     ws.addEventListener("message", (ev) => {
-      lastMessageAt = Date.now();
+      state.value.lastMessageAt = performance.now();
       try {
         const data = JSON.parse(ev.data as string);
         if (data?.type === "ping") {


### PR DESCRIPTION
## Summary

Fixes 15 bugs identified in a full-codebase sweep, spanning 9 Go handlers and one frontend composable.

**HIGH — server crash / data corruption**
- `tag.go`: `uuid.MustParse` panics on invalid input → replaced with `uuid.Parse` + HTTP 400
- `tag.go`: `SyncFileTags`/`SyncFolderTags` delete+insert not wrapped in a transaction → partial tag state on any insert failure; now uses `h.db.Transaction(...)`
- `people.go`: `SplitFace` 5-step mutation had no transaction → corrupted person/face data on mid-sequence failure; now transactional
- `people.go`: `Merge` multi-step mutation had no transaction → same risk; now transactional
- `useNotificationsSocket.ts`: `heartbeatTimer` and `lastMessageAt` were per-call-site locals while WebSocket state is shared via `useState` → duplicate timers force-closed the shared socket after 35 s of apparent silence; both moved into shared `SocketState`

**MEDIUM — silent failures / wrong data returned to client**
- `auth.go`: post-`UpdateMe` user re-fetch error was ignored → zeroed struct returned on failure
- `library.go`: post-`Update` library re-fetch error ignored → same
- `file.go`: post-`Update` file re-fetch error ignored → same
- `file.go`: `libUUID, _ = uuid.Parse(...)` in `Delete` discarded parse error → nil UUID in activity log entries
- `people.go`: post-`Update` person re-fetch error ignored
- `invite.go`: `ErrAlreadyMember` branch hardcoded `"role": "owner"` regardless of actual role → now queries library owner and membership table for correct role
- `moment.go`: `Export` status DB update error discarded → job enqueued while DB still shows old status
- `search.go`: all three search queries ignored DB errors → silent HTTP 200 with empty results; now returns HTTP 500; supplementary label query logs and continues

**LOW**
- `member.go`: library and owner DB lookups in `ListUsers` had no error checks → zero-UUID propagation and empty owner row on failure

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/handlers/... -count=1` — 26/26 passed
- [x] `bun run typecheck` — clean