### PR TITLE
fix(frontend): order library trash tab after settings

### DIFF
--- a/frontend/app/components/LibraryTabs.vue
+++ b/frontend/app/components/LibraryTabs.vue
@@ -77,14 +77,7 @@ const browseTabs = computed<Tab[]>(() => {
 
 // Utility tabs: management surfaces, de-emphasised as icon-only on the right.
 const utilityTabs = computed<Tab[]>(() => {
-  const items: Tab[] = [
-    {
-      key: "trash",
-      label: "Trash",
-      icon: "i-lucide-trash-2",
-      to: `/libraries/${props.libraryId}/trash`,
-    },
-  ];
+  const items: Tab[] = [];
 
   if (props.canManageLibrary) {
     items.push({
@@ -94,6 +87,13 @@ const utilityTabs = computed<Tab[]>(() => {
       to: `/libraries/${props.libraryId}/settings`,
     });
   }
+
+  items.push({
+    key: "trash",
+    label: "Trash",
+    icon: "i-lucide-trash-2",
+    to: `/libraries/${props.libraryId}/trash`,
+  });
 
   return items;
 });


### PR DESCRIPTION
## What

Reorders the library utility tabs so the **Trash** icon comes *after* the **Settings** icon in `LibraryTabs.vue`.

## Why

Settings should sit before Trash in the icon-only utility tab group on the right of the library tab bar.

## How

In `utilityTabs`, the Settings tab is now seeded first (still gated by `canManageLibrary`) and the always-present Trash tab is appended after it, so render order becomes Settings → Trash. When the viewer can't manage the library, only Trash shows (unchanged).

## Verification

- `bun run test:unit` for `LibraryTabs`, `library` layout, and `library-index` — 26 passed
- `bun run typecheck` — clean
- `bun run lint` — clean (no new warnings)