### PR TITLE
feat(frontend): add Timeline and Map view-switcher icons to file browser

### DIFF
--- a/frontend/app/pages/libraries/[id]/index.vue
+++ b/frontend/app/pages/libraries/[id]/index.vue
@@ -1148,6 +1148,26 @@ const emptyStateDescription = computed(() => {
               @click="entryViewMode = 'card'"
             />
           </UTooltip>
+          <UTooltip text="Timeline">
+            <UButton
+              color="neutral"
+              variant="soft"
+              size="sm"
+              square
+              icon="i-lucide-clock"
+              :to="`/libraries/${libraryId}/timeline`"
+            />
+          </UTooltip>
+          <UTooltip text="Map">
+            <UButton
+              color="neutral"
+              variant="soft"
+              size="sm"
+              square
+              icon="i-lucide-map-pin"
+              :to="`/libraries/${libraryId}/map`"
+            />
+          </UTooltip>
         </template>
 
         <UButton


### PR DESCRIPTION
## Summary

Surfaces the **Timeline** and **Map** views as icon buttons directly in the Files view-switcher row, right next to the existing **List view** and **Grid view** toggles.

- Reuses the same tab icons — `i-lucide-clock` (Timeline) and `i-lucide-map-pin` (Map) — for visual consistency with `LibraryTabs`.
- Styled identically to the List/Grid buttons (`UTooltip` + soft `square` `UButton`, `size="sm"`).
- Since Timeline and Map are separate routed pages (not in-page view modes like List/Grid), these are neutral-colored navigation links to `/libraries/:id/timeline` and `/libraries/:id/map` rather than active-state toggles.
- Only shown when not viewing trash, matching the List/Grid grouping.

## Testing

- `bun run typecheck` — passed
- `bun run lint` — clean (only pre-existing warnings in untouched files)
- `bun run test:unit` — 962 passed, 0 failed
- Visual review via the `library-browser` screenshot e2e flow — new icons render correctly and align well in both light and dark themes.