### PR TITLE
fix(website): enable client-side routing to remove docs page flash

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -26,6 +26,12 @@ export default defineConfig({
 				baseUrl: `${REPO}/edit/main/website/`,
 			},
 			lastUpdated: true,
+			components: {
+				// Inject Astro's `<ClientRouter />` so navigation between docs
+				// pages is client-side (view transitions) instead of a full
+				// document reload — removes the white page flash.
+				Head: './src/components/Head.astro',
+			},
 			// Default social-card / OG metadata for documentation pages.
 			head: [
 				{ tag: 'meta', attrs: { property: 'og:image', content: `${SITE}/og-image.png` } },

--- a/website/src/components/Head.astro
+++ b/website/src/components/Head.astro
@@ -1,0 +1,19 @@
+---
+// Override of Starlight's default `Head` component.
+//
+// We render the stock Starlight head and then add Astro's `<ClientRouter />`,
+// which upgrades navigation between docs pages to client-side routing with
+// view transitions. Without it, every sidebar/link click triggers a full
+// document reload — a jarring white flash. The `head` config option only
+// accepts plain HTML tags, so adding an Astro component requires this override.
+//
+// Scope: this only affects Starlight docs pages. The marketing landing page
+// (LandingLayout.astro) keeps its own bespoke head + load-time scripts, so a
+// landing↔docs jump still does a normal navigation (a single boundary, not the
+// repeated flash you get while browsing the docs).
+import Default from '@astrojs/starlight/components/Head.astro';
+import { ClientRouter } from 'astro:transitions';
+---
+
+<Default><slot /></Default>
+<ClientRouter />


### PR DESCRIPTION
## Problem

Navigating between documentation pages on the docs site (`website/`, Astro + Starlight) triggers a **full document reload** — Astro's default multi-page navigation — producing a jarring white page flash on every sidebar/link click.

## Fix

Enable client-side routing via Astro's `<ClientRouter />` (view transitions), the officially documented approach for Starlight:

1. **`website/src/components/Head.astro`** (new) — overrides Starlight's default `Head`, renders it, then appends `<ClientRouter />`. An override is required because Starlight's `head` config option only accepts plain HTML tags, not Astro components.
2. **`website/astro.config.mjs`** — registers the override via `components: { Head: ... }`.

Docs→docs navigation now swaps content in place with a smooth transition instead of a flash, and Astro auto-enables link prefetch on top, so navigation also feels instant.

## Scope

Intentionally limited to Starlight docs pages. The marketing landing page (`LandingLayout.astro`) has its own bespoke `<head>` and load-time scripts (sticky nav, theme toggle, scroll-reveal, pointer glow) that run once on page load; wiring view transitions there would break them. A landing↔docs jump still does one normal navigation — a single boundary crossing, not the repeated flash while browsing docs.

## Verification

- `bun run build` — succeeds, all 25 pages built.
- Built docs pages (e.g. `dist/overview/index.html`) now contain the `astro-view-transitions-enabled` + fallback meta tags → client router active.
- Built landing page (`dist/index.html`) has 0 occurrences → confirmed untouched.
- `bun run check` (astro check) — 0 errors, 0 warnings.