### PR TITLE
fix(backend): gate audio taggers to published models so unavailable ones don't 404

### DIFF
--- a/backend/internal/handlers/admin_test.go
+++ b/backend/internal/handlers/admin_test.go
@@ -197,3 +197,48 @@ func TestAdmin_UpdateSettings_ValidatesMode(t *testing.T) {
 		t.Fatalf("expected 400, got %v", err)
 	}
 }
+
+// TestAdmin_UpdateSettings_RejectsUnpublishedAudioModel guards the audio-model
+// 404 regression: a model that is catalogued in the registry but whose weights
+// were never uploaded to the bucket (e.g. ced_base) must be refused here so it
+// can never be persisted and 404 the worker. A published model is accepted.
+func TestAdmin_UpdateSettings_RejectsUnpublishedAudioModel(t *testing.T) {
+	db := libraryTestDB(t)
+	h, svc := adminHandlerForTest(t, db)
+	e := newLibEcho()
+
+	owner := mustUser(t, db, "admin-audio@example.com")
+	owner.Role = "owner"
+	db.Save(&owner)
+
+	// Unpublished model → 400, setting unchanged.
+	body := `{"audio_detect_model":"ced_base"}`
+	req := httptest.NewRequest(http.MethodPatch, "/admin/settings", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := ctxWithUser(e, req, rec, owner.ID)
+	err := h.requireOwnerMiddleware(h.UpdateSettings)(c)
+	httpErr, ok := err.(*echo.HTTPError)
+	if !ok || httpErr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unpublished model, got %v", err)
+	}
+	if got := svc.Get().AudioDetectModel; got == "ced_base" {
+		t.Fatalf("unpublished model must not be persisted, got %q", got)
+	}
+
+	// Published model → 200, persisted.
+	body = `{"audio_detect_model":"pann_cnn14"}`
+	req = httptest.NewRequest(http.MethodPatch, "/admin/settings", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec = httptest.NewRecorder()
+	c = ctxWithUser(e, req, rec, owner.ID)
+	if err := h.requireOwnerMiddleware(h.UpdateSettings)(c); err != nil {
+		t.Fatalf("UpdateSettings(published): %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for published model, got %d", rec.Code)
+	}
+	if got := svc.Get().AudioDetectModel; got != "pann_cnn14" {
+		t.Fatalf("expected audio_detect_model=pann_cnn14, got %q", got)
+	}
+}

--- a/backend/internal/services/audiodetection/audiodetection_test.go
+++ b/backend/internal/services/audiodetection/audiodetection_test.go
@@ -521,12 +521,16 @@ func TestExtractAudio_Success(t *testing.T) {
 // --- registry.go: LookupSpec known-id branch (fills the remaining branch) ---
 
 func TestLookupSpec_KnownIDHit(t *testing.T) {
-	spec, ok := LookupSpec("ced_base")
+	// Use a published model — LookupSpec only reports a hit for selectable
+	// (Available) entries. pann_cnn14 is on the bucket and distinct from the
+	// default, so it exercises the known-id branch without colliding with the
+	// fallback path.
+	spec, ok := LookupSpec("pann_cnn14")
 	if !ok {
-		t.Fatal("expected hit for known id")
+		t.Fatal("expected hit for known, published id")
 	}
-	if spec.ID != "ced_base" {
-		t.Errorf("spec.ID = %q, want ced_base", spec.ID)
+	if spec.ID != "pann_cnn14" {
+		t.Errorf("spec.ID = %q, want pann_cnn14", spec.ID)
 	}
 }
 

--- a/backend/internal/services/audiodetection/registry.go
+++ b/backend/internal/services/audiodetection/registry.go
@@ -24,6 +24,15 @@ type ModelSpec struct {
 	MAP        float64 // AudioSet AS-2M mAP for the option callout.
 	License    string  // SPDX-ish — Apache-2.0 / MIT etc.
 	Notes      string  // 1-line subtitle for the admin UI.
+
+	// Available reports whether ModelFile is actually mirrored to the model
+	// bucket today. Entries that are catalogued but not yet uploaded stay in
+	// the registry (Available:false) so the roadmap + metadata remain
+	// documented, but IsValidModelID refuses to select them and LookupSpec
+	// falls back to the default — otherwise the worker would 404 at download
+	// time and fail every audio-detect job. Flip to true in the SAME change
+	// that uploads the ONNX artifact (see docs/internal/publishing-models.md).
+	Available bool
 }
 
 // DefaultModelID is the registry entry selected on fresh installs. This
@@ -37,9 +46,17 @@ const DefaultModelID = "efficientat_mn10"
 // debugging only; the admin handler rejects unknown IDs up front.
 const LegacyModelID = "pann_cnn14"
 
-// Registry is the authoritative list of selectable audio-tagging models.
-// Add new entries here AND in docs/models.md AND upload the ONNX artifact
-// to s3.rustyguts.net/models/ via scripts/export-audio-tagger.py.
+// Registry is the authoritative list of audio-tagging models. Add new
+// entries here AND in docs/models.md. An entry is only *selectable* once its
+// ONNX artifact is mirrored to s3.rustyguts.net/models/ (via
+// scripts/export-audio-tagger.py) and Available is flipped to true — see the
+// ModelSpec.Available doc.
+//
+// AVAILABILITY: only pann_cnn14 + efficientat_mn10 are currently published to
+// the bucket. efficientat_mn04/mn40 and ced_tiny/small/base are catalogued but
+// NOT yet uploaded, so they stay Available:false until someone runs the
+// publish flow. Marking them Available without uploading reintroduces the
+// "ced_base.onnx 404 fails every audio-detect job" bug.
 var Registry = map[string]ModelSpec{
 	"pann_cnn14": {
 		ID:         "pann_cnn14",
@@ -51,6 +68,7 @@ var Registry = map[string]ModelSpec{
 		MAP:        0.431,
 		License:    "Apache-2.0",
 		Notes:      "Original baseline. Raw waveform input, no mel preprocessing.",
+		Available:  true,
 	},
 	"efficientat_mn04": {
 		ID:         "efficientat_mn04",
@@ -62,6 +80,7 @@ var Registry = map[string]ModelSpec{
 		MAP:        0.432,
 		License:    "MIT",
 		Notes:      "Same mAP as CNN14 at ~80× smaller. Best for ultra-constrained pods.",
+		Available:  false, // not yet mirrored to the model bucket
 	},
 	"efficientat_mn10": {
 		ID:         "efficientat_mn10",
@@ -73,6 +92,7 @@ var Registry = map[string]ModelSpec{
 		MAP:        0.471,
 		License:    "MIT",
 		Notes:      "Default. ~16× smaller than CNN14, +9% mAP, faster on CPU.",
+		Available:  true,
 	},
 	"efficientat_mn40": {
 		ID:         "efficientat_mn40",
@@ -84,6 +104,7 @@ var Registry = map[string]ModelSpec{
 		MAP:        0.487,
 		License:    "MIT",
 		Notes:      "Same disk class as CNN14, +5.6 mAP. Slower CPU inference.",
+		Available:  false, // not yet mirrored to the model bucket
 	},
 	"ced_tiny": {
 		ID:         "ced_tiny",
@@ -95,6 +116,7 @@ var Registry = map[string]ModelSpec{
 		MAP:        0.481,
 		License:    "Apache-2.0",
 		Notes:      "Transformer; CPU parity with MobileNetV3 per authors.",
+		Available:  false, // not yet mirrored to the model bucket
 	},
 	"ced_small": {
 		ID:         "ced_small",
@@ -106,6 +128,7 @@ var Registry = map[string]ModelSpec{
 		MAP:        0.496,
 		License:    "Apache-2.0",
 		Notes:      "Best mid-range quality.",
+		Available:  false, // not yet mirrored to the model bucket
 	},
 	"ced_base": {
 		ID:         "ced_base",
@@ -117,34 +140,57 @@ var Registry = map[string]ModelSpec{
 		MAP:        0.500,
 		License:    "Apache-2.0",
 		Notes:      "SOTA-class quality, same disk class as PANN CNN14.",
+		Available:  false, // not yet mirrored to the model bucket
 	},
 }
 
-// LookupSpec returns the ModelSpec for an ID, or the default spec when id
-// is empty or unknown. The bool reports whether the lookup hit the registry.
+// LookupSpec returns the ModelSpec for an ID, or the default spec when id is
+// empty, unknown, OR not Available. The bool reports whether the lookup
+// resolved to a usable (published) model. An unavailable selection — e.g. a
+// settings row pointing at a model that was catalogued but never uploaded —
+// falls back to the default so the worker runs a model that actually exists
+// on the bucket instead of 404ing at download time. DefaultModelID must stay
+// Available (asserted in registry_test.go) for this fallback to be safe.
 func LookupSpec(id string) (ModelSpec, bool) {
 	if id == "" {
 		return Registry[DefaultModelID], false
 	}
 	spec, ok := Registry[id]
-	if !ok {
+	if !ok || !spec.Available {
 		return Registry[DefaultModelID], false
 	}
 	return spec, true
 }
 
-// IsValidModelID reports whether id is a known registry entry.
+// IsValidModelID reports whether id is a known AND currently-selectable
+// (published) registry entry. The admin settings handler uses this to reject
+// selecting a model whose ONNX artifact isn't on the bucket yet.
 func IsValidModelID(id string) bool {
-	_, ok := Registry[id]
-	return ok
+	spec, ok := Registry[id]
+	return ok && spec.Available
 }
 
-// ModelList returns registry entries sorted by ID for deterministic admin
-// API responses + test fixtures.
+// ModelList returns all registry entries sorted by ID for deterministic admin
+// API responses + test fixtures, including catalogued-but-unpublished models
+// (inspect ModelSpec.Available to tell them apart).
 func ModelList() []ModelSpec {
 	out := make([]ModelSpec, 0, len(Registry))
 	for _, m := range Registry {
 		out = append(out, m)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// AvailableModelList returns only the currently-selectable (published)
+// registry entries, sorted by ID. This is the set an admin can actually pick
+// without breaking audio detection.
+func AvailableModelList() []ModelSpec {
+	out := make([]ModelSpec, 0, len(Registry))
+	for _, m := range Registry {
+		if m.Available {
+			out = append(out, m)
+		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out

--- a/backend/internal/services/audiodetection/registry_test.go
+++ b/backend/internal/services/audiodetection/registry_test.go
@@ -55,14 +55,68 @@ func TestLookupSpec_EmptyIDReturnsDefault(t *testing.T) {
 }
 
 func TestIsValidModelID(t *testing.T) {
-	for _, id := range []string{"pann_cnn14", "efficientat_mn04", "efficientat_mn10", "efficientat_mn40", "ced_tiny", "ced_small", "ced_base"} {
+	// Only models whose ONNX artifact is published to the bucket are
+	// selectable. pann_cnn14 + efficientat_mn10 are the two currently mirrored.
+	for _, id := range []string{"pann_cnn14", "efficientat_mn10"} {
 		if !IsValidModelID(id) {
-			t.Errorf("IsValidModelID(%q) = false, want true", id)
+			t.Errorf("IsValidModelID(%q) = false, want true (published model)", id)
+		}
+	}
+	// Known registry entries that are catalogued but NOT yet uploaded must be
+	// rejected — selecting them would 404 the worker and fail every job.
+	for _, id := range []string{"efficientat_mn04", "efficientat_mn40", "ced_tiny", "ced_small", "ced_base"} {
+		if IsValidModelID(id) {
+			t.Errorf("IsValidModelID(%q) = true, want false (not published to the bucket)", id)
 		}
 	}
 	for _, id := range []string{"", "panns_cnn14", "wavegram", "BEATs", "ced", "mn10"} {
 		if IsValidModelID(id) {
 			t.Errorf("IsValidModelID(%q) = true, want false", id)
+		}
+	}
+}
+
+func TestRegistry_DefaultAndLegacyAreAvailable(t *testing.T) {
+	// LookupSpec falls back to DefaultModelID for empty/unknown/unavailable
+	// IDs, so the default MUST itself be published or the fallback 404s. The
+	// legacy PANN model is also kept selectable as a rollback path.
+	for _, id := range []string{DefaultModelID, LegacyModelID} {
+		spec, ok := Registry[id]
+		if !ok {
+			t.Fatalf("%q missing from registry", id)
+		}
+		if !spec.Available {
+			t.Errorf("%q must be Available (selectable + on the bucket)", id)
+		}
+	}
+}
+
+func TestLookupSpec_UnavailableFallsBackToDefault(t *testing.T) {
+	// A settings row pointing at a catalogued-but-unpublished model (e.g. an
+	// admin selected ced_base before it was gated) must fall back to the
+	// default rather than resolving to a spec the worker can't download.
+	spec, ok := LookupSpec("ced_base")
+	if ok {
+		t.Fatal("expected ced_base to be treated as unavailable (miss)")
+	}
+	if spec.ID != DefaultModelID {
+		t.Fatalf("fallback ID: got %q want %q", spec.ID, DefaultModelID)
+	}
+}
+
+func TestAvailableModelList_OnlyPublished(t *testing.T) {
+	list := AvailableModelList()
+	if len(list) == 0 {
+		t.Fatal("AvailableModelList is empty; the default would be unselectable")
+	}
+	for _, m := range list {
+		if !m.Available {
+			t.Errorf("AvailableModelList included unavailable model %q", m.ID)
+		}
+	}
+	for i := 1; i < len(list); i++ {
+		if list[i-1].ID > list[i].ID {
+			t.Errorf("AvailableModelList not sorted: %q after %q", list[i].ID, list[i-1].ID)
 		}
 	}
 }

--- a/backend/internal/services/audiodetection/worker.go
+++ b/backend/internal/services/audiodetection/worker.go
@@ -56,13 +56,19 @@ func NewTaskHandler(db *gorm.DB, storageSvc *storage.Service, cfg *config.Config
 
 // activeSpec returns the ModelSpec for the admin-selected tagger, with
 // fallback to the registry default. Unknown IDs (e.g. left over from a
-// rolled-back deploy) fall back rather than failing the job.
+// rolled-back deploy) AND unavailable IDs (a model catalogued but not yet
+// published to the bucket — selecting it would 404) fall back rather than
+// failing the job. A non-empty ID that misses is logged so operators can see
+// why their selection isn't taking effect.
 func (h *TaskHandler) activeSpec() ModelSpec {
 	id := ""
 	if h.settingsSvc != nil {
 		id = h.settingsSvc.Get().AudioDetectModel
 	}
-	spec, _ := LookupSpec(id)
+	spec, ok := LookupSpec(id)
+	if id != "" && !ok {
+		log.Printf("audio-detect: configured model %q is unknown or not published; falling back to %q", id, spec.ID)
+	}
 	return spec
 }
 

--- a/docs/internal/todos.md
+++ b/docs/internal/todos.md
@@ -68,6 +68,33 @@ E2e green. Watch for snapshot drift after Tailwind/font changes —
 - **Risk:** Low code-wise; this is mainly a product/privacy decision. Tracked from the PR #552 review.
 
 
+## 9. Publish the catalogued-but-missing audio-tagger models (ML) — OPEN
+
+- **What:** Five of the seven models in `audiodetection.Registry` were never
+  uploaded to the model bucket — `efficientat_mn04_as.onnx`,
+  `efficientat_mn40_as_ext.onnx`, `ced_tiny.onnx`, `ced_small.onnx`,
+  `ced_base.onnx` all 404 at `https://s3.rustyguts.net/models/` (verified
+  2026-06-04 against the live bucket listing; only `efficientat_mn10_as.onnx`
+  and `panns_cnn14.onnx` are present). Selecting any of them used to fail every
+  audio-detect job with a 404 at model-download time ("ced_base.onnx 404").
+- **Interim fix (2026-06-04):** added `ModelSpec.Available` and gated the
+  catalog — `IsValidModelID` rejects unavailable models, `LookupSpec` falls
+  back to the default for a stored-but-unavailable selection (self-heals an
+  admin who already picked `ced_base`), and the admin picker renders them
+  disabled ("— not yet available"). Jobs no longer fail; the unpublished models
+  are simply not selectable yet.
+- **To actually ship them:** run the export + publish flow in
+  `docs/internal/publishing-models.md` (`scripts/export-audio-tagger.py` →
+  rclone to `rustyguts:models/`), then flip `Available: true` on the matching
+  registry entries AND set `available: true` in the `audioTaggers` array in
+  `frontend/app/pages/admin/index.vue`, in the SAME change. Update the Status
+  columns in `website/.../features/audio-detection-and-transcription.md` and
+  `website/.../architecture/ml-models-runtime.md`.
+- **Effort:** M (export needs a torch venv; uploads are 5–330 MB each).
+- **Risk:** Low — gated behind `Available`; a half-finished upload just stays
+  unselectable.
+
+
 ---
 
 ## Completed

--- a/frontend/app/pages/admin/index.vue
+++ b/frontend/app/pages/admin/index.vue
@@ -95,16 +95,21 @@ interface AudioTaggerOption {
   mAP: number;
   license: string;
   notes: string;
+  // available mirrors audiodetection.ModelSpec.Available on the backend: a
+  // model is only selectable once its ONNX artifact is published to the model
+  // bucket. Unpublished entries stay listed (disabled) so the roadmap is
+  // visible, but picking one would 404 the worker — the backend rejects it too.
+  available: boolean;
 }
 
 const audioTaggers: AudioTaggerOption[] = [
-  { id: "efficientat_mn04", label: "EfficientAT mn04_as (tiny)", diskMB: 5, ramPeakMB: 60, mAP: 0.432, license: "MIT", notes: "Same mAP as CNN14 at ~80× smaller. Best for ultra-constrained pods." },
-  { id: "efficientat_mn10", label: "EfficientAT mn10_as (default)", diskMB: 20, ramPeakMB: 120, mAP: 0.471, license: "MIT", notes: "~16× smaller than CNN14, +9% mAP, faster on CPU." },
-  { id: "efficientat_mn40", label: "EfficientAT mn40_as_ext", diskMB: 280, ramPeakMB: 500, mAP: 0.487, license: "MIT", notes: "Same disk class as CNN14, +5.6 mAP. Slower CPU inference." },
-  { id: "ced_tiny", label: "CED-Tiny", diskMB: 22, ramPeakMB: 120, mAP: 0.481, license: "Apache-2.0", notes: "Transformer; CPU parity with MobileNetV3." },
-  { id: "ced_small", label: "CED-Small", diskMB: 85, ramPeakMB: 280, mAP: 0.496, license: "Apache-2.0", notes: "Best mid-range quality." },
-  { id: "ced_base", label: "CED-Base (premium)", diskMB: 330, ramPeakMB: 600, mAP: 0.500, license: "Apache-2.0", notes: "SOTA-class quality." },
-  { id: "pann_cnn14", label: "PANNs CNN14 (legacy)", diskMB: 313, ramPeakMB: 600, mAP: 0.431, license: "Apache-2.0", notes: "Original baseline. Kept as rollback option." },
+  { id: "efficientat_mn04", label: "EfficientAT mn04_as (tiny)", diskMB: 5, ramPeakMB: 60, mAP: 0.432, license: "MIT", notes: "Same mAP as CNN14 at ~80× smaller. Best for ultra-constrained pods.", available: false },
+  { id: "efficientat_mn10", label: "EfficientAT mn10_as (default)", diskMB: 20, ramPeakMB: 120, mAP: 0.471, license: "MIT", notes: "~16× smaller than CNN14, +9% mAP, faster on CPU.", available: true },
+  { id: "efficientat_mn40", label: "EfficientAT mn40_as_ext", diskMB: 280, ramPeakMB: 500, mAP: 0.487, license: "MIT", notes: "Same disk class as CNN14, +5.6 mAP. Slower CPU inference.", available: false },
+  { id: "ced_tiny", label: "CED-Tiny", diskMB: 22, ramPeakMB: 120, mAP: 0.481, license: "Apache-2.0", notes: "Transformer; CPU parity with MobileNetV3.", available: false },
+  { id: "ced_small", label: "CED-Small", diskMB: 85, ramPeakMB: 280, mAP: 0.496, license: "Apache-2.0", notes: "Best mid-range quality.", available: false },
+  { id: "ced_base", label: "CED-Base (premium)", diskMB: 330, ramPeakMB: 600, mAP: 0.500, license: "Apache-2.0", notes: "SOTA-class quality.", available: false },
+  { id: "pann_cnn14", label: "PANNs CNN14 (legacy)", diskMB: 313, ramPeakMB: 600, mAP: 0.431, license: "Apache-2.0", notes: "Original baseline. Kept as rollback option.", available: true },
 ];
 
 function formatMB(mb: number): string {
@@ -493,7 +498,7 @@ const columns: TableColumn<AdminUser>[] = [
           </div>
           <USelect
             :model-value="audioTaggerDraft ?? 'efficientat_mn10'"
-            :items="audioTaggers.map((m) => ({ label: m.label, value: m.id }))"
+            :items="audioTaggers.map((m) => ({ label: m.available ? m.label : `${m.label} — not yet available`, value: m.id, disabled: !m.available }))"
             :disabled="updatingAudioTagger"
             size="sm"
             @update:model-value="(v: string) => { audioTaggerDraft = v; updateAudioTagger(v); }"

--- a/frontend/test/pages/admin-settings.spec.ts
+++ b/frontend/test/pages/admin-settings.spec.ts
@@ -90,7 +90,7 @@ beforeEach(() => {
     registration_mode: "invite_only",
     whisper_model: "tiny",
     whisper_language: "fr",
-    audio_detect_model: "ced_small",
+    audio_detect_model: "pann_cnn14",
   });
 });
 
@@ -143,13 +143,16 @@ describe("admin settings handlers", () => {
   });
 
   it("updates the audio tagger via the select", async () => {
+    // Only published models are selectable (pann_cnn14 + efficientat_mn10);
+    // unpublished entries like ced_small are rendered disabled and rejected by
+    // the backend. Switch to the legacy PANN model, which is available.
     const wrapper = mountPage();
     const selects = wrapper.findAll("select");
-    await selects[2]!.setValue("ced_small");
+    await selects[2]!.setValue("pann_cnn14");
     await vi.waitFor(() => {
       expect(mocks.apiFetch).toHaveBeenCalledWith("/api/admin/settings", {
         method: "PATCH",
-        body: { audio_detect_model: "ced_small" },
+        body: { audio_detect_model: "pann_cnn14" },
       });
     });
   });

--- a/website/src/content/docs/architecture/ml-models-runtime.md
+++ b/website/src/content/docs/architecture/ml-models-runtime.md
@@ -56,15 +56,17 @@ Labels files with COCO-80 object classes (person, car, dog, and so on). The mode
 
 Classifies audio into 527 AudioSet event classes (music, speech, dog bark, machinery, and so on). Each model in the registry bundles the mel-spectrogram transform inside the ONNX graph so the worker only feeds raw mono PCM. The active model is selectable from the admin panel at runtime.
 
-| ID | Disk | mAP | Notes |
-|---|---|---|---|
-| `efficientat_mn04` | 5 MB | 0.432 | Smallest; fast on constrained hardware |
-| **`efficientat_mn10`** (default) | 20 MB | 0.471 | Best balance of size and accuracy |
-| `efficientat_mn40` | 280 MB | 0.487 | Higher accuracy, larger footprint |
-| `ced_tiny` | 22 MB | 0.481 | Good accuracy-to-size ratio |
-| `ced_small` | 85 MB | 0.496 | |
-| `ced_base` | 330 MB | 0.500 | Highest mAP in the registry |
-| `pann_cnn14` (legacy) | 313 MB | 0.431 | Kept for rollback; not recommended for new installs |
+The registry catalogues several models, but a model is only **selectable** once its ONNX weights are mirrored to the model bucket. Entries whose weights are not yet published carry `Available: false` in `audiodetection.Registry`: the admin API rejects selecting them, the picker renders them disabled, and `LookupSpec` falls back to the default for any stored-but-unavailable selection — so a stale setting can never make the worker 404 on a missing file. Flip `Available` to `true` in the same change that uploads the artifact.
+
+| ID | Disk | mAP | Status | Notes |
+|---|---|---|---|---|
+| `efficientat_mn04` | 5 MB | 0.432 | Planned | Smallest; fast on constrained hardware |
+| **`efficientat_mn10`** (default) | 20 MB | 0.471 | Available | Best balance of size and accuracy |
+| `efficientat_mn40` | 280 MB | 0.487 | Planned | Higher accuracy, larger footprint |
+| `ced_tiny` | 22 MB | 0.481 | Planned | Good accuracy-to-size ratio |
+| `ced_small` | 85 MB | 0.496 | Planned | |
+| `ced_base` | 330 MB | 0.500 | Planned | Highest mAP in the registry |
+| `pann_cnn14` (legacy) | 313 MB | 0.431 | Available | Kept for rollback; not recommended for new installs |
 
 | Property | Value |
 |---|---|

--- a/website/src/content/docs/features/audio-detection-and-transcription.md
+++ b/website/src/content/docs/features/audio-detection-and-transcription.md
@@ -111,18 +111,25 @@ with roughly 8× faster processing and less than 1 GB RAM at peak.
 The instance owner selects the audio detection model from the same
 **Admin → Inference Models** page.
 
-| Model | Disk | Accuracy (mAP) | License |
-|---|---|---|---|
-| `efficientat_mn04` | 5 MB | 0.432 | MIT |
-| **`efficientat_mn10` (default)** | 20 MB | 0.471 | MIT |
-| `efficientat_mn40` | 280 MB | 0.487 | MIT |
-| `ced_tiny` | 22 MB | 0.481 | Apache-2.0 |
-| `ced_small` | 85 MB | 0.496 | Apache-2.0 |
-| `ced_base` | 330 MB | 0.500 | Apache-2.0 |
+| Model | Disk | Accuracy (mAP) | License | Status |
+|---|---|---|---|---|
+| `efficientat_mn04` | 5 MB | 0.432 | MIT | Planned |
+| **`efficientat_mn10` (default)** | 20 MB | 0.471 | MIT | Available |
+| `efficientat_mn40` | 280 MB | 0.487 | MIT | Planned |
+| `ced_tiny` | 22 MB | 0.481 | Apache-2.0 | Planned |
+| `ced_small` | 85 MB | 0.496 | Apache-2.0 | Planned |
+| `ced_base` | 330 MB | 0.500 | Apache-2.0 | Planned |
+| `pann_cnn14` (legacy) | 313 MB | 0.431 | Apache-2.0 | Available |
 
 The default `efficientat_mn10` is a practical balance of size (20 MB) and
-accuracy. For the best accuracy at the cost of more disk and RAM, try
-`ced_base`.
+accuracy. `pann_cnn14` is the original baseline, kept selectable as a
+rollback option.
+
+Models marked **Planned** are catalogued but their weights are not yet
+published to the model bucket. They appear greyed-out in the admin picker and
+cannot be selected — choosing one would otherwise fail every audio-detect job
+with a 404 when the worker tries to download the missing file. They become
+selectable once their weights are published.
 
 Models download automatically the first time they are needed, so the initial
 run of a new model may take longer while the file is fetched.


### PR DESCRIPTION
## Problem

Audio-detect jobs failed for any owner who selected certain tagger models — e.g. `ced_base` — with a 404 at model-download time.

Root cause: the audio-tagger registry (`audiodetection.Registry`) and the admin picker advertised **7** models, but only **2** were ever mirrored to the model bucket (`s3.rustyguts.net/models/`). Verified against the live bucket listing:

| Model | On bucket? |
|---|---|
| `efficientat_mn10` (default) | ✅ |
| `pann_cnn14` (legacy) | ✅ |
| `efficientat_mn04` | ❌ 404 |
| `efficientat_mn40` | ❌ 404 |
| `ced_tiny` | ❌ 404 |
| `ced_small` | ❌ 404 |
| `ced_base` | ❌ 404 |

Selecting any of the 5 unpublished models made `EnsureAssets` download a missing file, return a hard (non-transient) error, and fail every audio-detect job.

Uploading the missing 5–330 MB ONNX artifacts needs the torch export pipeline + private push creds (out of scope for this change), so this PR **gates the catalog to what's actually published** and makes a stale selection self-heal.

## Changes

- **`registry.go`** — add `ModelSpec.Available`; only the 2 published models are `true`.
  - `IsValidModelID` rejects models whose weights aren't published → the admin settings PATCH refuses to persist them.
  - `LookupSpec` falls back to the default for an empty, unknown, **or unavailable** selection → a settings row left pointing at `ced_base` now self-heals to the default instead of 404ing the worker.
  - Added `AvailableModelList()`.
- **`worker.go`** — `activeSpec` logs when it falls back, so operators see why a selection isn't taking effect.
- **`admin/index.vue`** — unpublished models render **disabled** ("— not yet available") in the picker; the backend rejects them as defense-in-depth.
- **Docs** — added a **Status** column to the feature + architecture model tables; recorded the publishing gap and the re-enable steps in `docs/internal/todos.md` (item 9).

To actually ship one of the planned models later: run the publish flow in `docs/internal/publishing-models.md`, then flip `Available: true` (backend) **and** `available: true` (frontend) in the same change.

## Testing

- Backend: `go test ./... -race -count=1` → **27 packages ok, 0 FAIL, 0 data races**. New tests:
  - registry gating (`IsValidModelID` / `LookupSpec` / `AvailableModelList` / default-is-available)
  - handler: `audio_detect_model: ced_base` → 400 (not persisted), `pann_cnn14` → 200 (persisted)
- Frontend: `typecheck` clean; full unit suite **962 passed / 0 failed**; updated the admin tagger test to the new contract.