### PR TITLE
build(backend): upgrade onnxruntime_go v1.31.0 + ONNX Runtime 1.26.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,11 @@ jobs:
 
       - name: Install ONNX Runtime
         run: |
-          # Must match the API version onnxruntime_go links against (ORT 1.25.x /
-          # API v25). An older runtime fails ONNX init with
-          # "requested API version [25] is not available", which would skip every
+          # Must match the API version onnxruntime_go links against (ORT 1.26.x /
+          # API v26). An older runtime fails ONNX init with
+          # "requested API version [26] is not available", which would skip every
           # real face/object/audio inference test.
-          ONNX_VERSION=1.25.0
+          ONNX_VERSION=1.26.0
           ARCH=$(dpkg --print-architecture)
           if [ "$ARCH" = "arm64" ]; then ONNX_ARCH="aarch64"; else ONNX_ARCH="x64"; fi
           wget -q "https://github.com/microsoft/onnxruntime/releases/download/v${ONNX_VERSION}/onnxruntime-linux-${ONNX_ARCH}-${ONNX_VERSION}.tgz"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,13 @@ RUN ARCH=$(dpkg --print-architecture) && \
     else \
       ONNX_ARCH="x64"; \
     fi && \
-    wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.25.0/onnxruntime-linux-${ONNX_ARCH}-1.25.0.tgz && \
-    tar -xzf onnxruntime-linux-${ONNX_ARCH}-1.25.0.tgz && \
-    cp -r onnxruntime-linux-${ONNX_ARCH}-1.25.0/lib/* /usr/local/lib/ && \
-    cp -r onnxruntime-linux-${ONNX_ARCH}-1.25.0/include/* /usr/local/include/ && \
+    wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.26.0/onnxruntime-linux-${ONNX_ARCH}-1.26.0.tgz && \
+    tar -xzf onnxruntime-linux-${ONNX_ARCH}-1.26.0.tgz && \
+    cp -r onnxruntime-linux-${ONNX_ARCH}-1.26.0/lib/* /usr/local/lib/ && \
+    cp -r onnxruntime-linux-${ONNX_ARCH}-1.26.0/include/* /usr/local/include/ && \
     strip --strip-unneeded /usr/local/lib/libonnxruntime*.so* || true && \
     ldconfig && \
-    rm -rf onnxruntime-linux-${ONNX_ARCH}-1.25.0*
+    rm -rf onnxruntime-linux-${ONNX_ARCH}-1.26.0*
 
 WORKDIR /backend
 COPY backend/go.mod backend/go.sum ./

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,13 +19,13 @@ RUN ARCH=$(dpkg --print-architecture) && \
     else \
         ONNX_ARCH="x64"; \
     fi && \
-    wget https://github.com/microsoft/onnxruntime/releases/download/v1.25.0/onnxruntime-linux-${ONNX_ARCH}-1.25.0.tgz && \
-    tar -xzf onnxruntime-linux-${ONNX_ARCH}-1.25.0.tgz && \
-    cp -r onnxruntime-linux-${ONNX_ARCH}-1.25.0/lib/* /usr/local/lib/ && \
-    cp -r onnxruntime-linux-${ONNX_ARCH}-1.25.0/include/* /usr/local/include/ && \
+    wget https://github.com/microsoft/onnxruntime/releases/download/v1.26.0/onnxruntime-linux-${ONNX_ARCH}-1.26.0.tgz && \
+    tar -xzf onnxruntime-linux-${ONNX_ARCH}-1.26.0.tgz && \
+    cp -r onnxruntime-linux-${ONNX_ARCH}-1.26.0/lib/* /usr/local/lib/ && \
+    cp -r onnxruntime-linux-${ONNX_ARCH}-1.26.0/include/* /usr/local/include/ && \
     ln -sf /usr/local/lib/libonnxruntime.so /usr/local/lib/onnxruntime.so && \
     ldconfig && \
-    rm -rf onnxruntime-linux-${ONNX_ARCH}-1.25.0*
+    rm -rf onnxruntime-linux-${ONNX_ARCH}-1.26.0*
 
 # Build whisper.cpp (whisper-cli) for transcription. Models are downloaded at runtime.
 #

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/redis/go-redis/v9 v9.20.0
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
-	github.com/yalue/onnxruntime_go v1.30.1
+	github.com/yalue/onnxruntime_go v1.31.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/oauth2 v0.36.0
 	gorm.io/driver/postgres v1.6.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -113,8 +113,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/yalue/onnxruntime_go v1.30.1 h1:NaEng5lWbsHZ/8X1dtaw1mIj7eV1ozyjbFo//g0ktl4=
-github.com/yalue/onnxruntime_go v1.30.1/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
+github.com/yalue/onnxruntime_go v1.31.0 h1:1ln4YW1SFOFfGJZXe3jNOb2JUSt+l2pEneZfV8HdtFA=
+github.com/yalue/onnxruntime_go v1.31.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/backend/internal/testsupport/testdata/README.md
+++ b/backend/internal/testsupport/testdata/README.md
@@ -38,7 +38,7 @@ ffmpeg -i /tmp/s.aiff -ac 1 -ar 16000 -acodec pcm_s16le audio/speech_hello.wav
 
 ## Running the real-inference tests locally
 
-The ONNX-based tests (face/object/audio) need an **ONNX Runtime 1.25.x** shared
+The ONNX-based tests (face/object/audio) need an **ONNX Runtime 1.26.x** shared
 library matching `onnxruntime_go` (see `internal/testsupport/onnxtest`). On a
 host without it installed system-wide, point the suite at one:
 

--- a/website/src/content/docs/architecture/ml-models-runtime.md
+++ b/website/src/content/docs/architecture/ml-models-runtime.md
@@ -193,7 +193,7 @@ The audio detection session is load-probed across 96 input/output name combinati
 `backend/Dockerfile` is a multi-stage build. It ships the inference runtime but not the model weights.
 
 - **Build stage** (`golang:1.26-bookworm`): installs `libvips-dev` (image preprocessing), `ffmpeg` (audio/video decoding), `libgomp1` (OpenMP for ONNX), and build tools. Built with `CGO_ENABLED=1`.
-- **ONNX Runtime v1.25.0**: downloaded from GitHub releases with architecture-aware selection (`arm64` or `x64`), installed to `/usr/local/lib`, stripped, and symlinked as `onnxruntime.so`. `ldconfig` runs after install. The runtime **must be 1.25.x** to match the version pinned by `onnxruntime_go`.
+- **ONNX Runtime v1.26.0**: downloaded from GitHub releases with architecture-aware selection (`arm64` or `x64`), installed to `/usr/local/lib`, stripped, and symlinked as `onnxruntime.so`. `ldconfig` runs after install. The runtime **must be 1.26.x** to match the version pinned by `onnxruntime_go`.
 - **whisper.cpp v1.8.4** (separate stage): shallow-cloned at the pinned tag, built with CMake Release mode (AVX/AVX2/FMA/F16C enabled; AVX-512 disabled). Produces `whisper-cli` and the required shared libraries.
 - **Final image** (`debian:bookworm-slim`): copies the ONNX Runtime library, `whisper-cli`, and whisper shared libraries. Sets `ENV LD_LIBRARY_PATH=/usr/local/lib` — this is required because the Go ONNX bindings call `dlopen("onnxruntime.so")` without an absolute path, and `onnxruntime.so` is not a SONAME, so `ldconfig` alone does not resolve it.
 
@@ -248,7 +248,7 @@ Each pipeline has a **real-data test** that runs actual inference end to end aga
 Fixtures plus their provenance and licenses live in `internal/testsupport/testdata/` (AI-generated faces + CC0 images + a locally synthesized speech clip). Shared setup is in `internal/testsupport` (`mlfixtures.go`, `onnxtest/`).
 
 :::note
-Every test **skips** (it never fails) when a dependency is missing — ffmpeg, `whisper-cli`, the test Postgres, the ONNX Runtime shared library, or the model weights. CI installs all of these (libvips + ffmpeg + ONNX Runtime + a whisper.cpp build), so the suite runs there. Locally, point it at a matching ONNX Runtime via `$ALCOVES_ONNXRUNTIME_LIB` and, optionally, a warm model cache via `$ALCOVES_MODELS_PATH` / `$ALCOVES_WHISPER_MODELS_DIR`. The ONNX Runtime must be 1.25.x to match `onnxruntime_go`.
+Every test **skips** (it never fails) when a dependency is missing — ffmpeg, `whisper-cli`, the test Postgres, the ONNX Runtime shared library, or the model weights. CI installs all of these (libvips + ffmpeg + ONNX Runtime + a whisper.cpp build), so the suite runs there. Locally, point it at a matching ONNX Runtime via `$ALCOVES_ONNXRUNTIME_LIB` and, optionally, a warm model cache via `$ALCOVES_MODELS_PATH` / `$ALCOVES_WHISPER_MODELS_DIR`. The ONNX Runtime must be 1.26.x to match `onnxruntime_go`.
 :::
 
 ---

--- a/website/src/content/docs/self-hosting/deploying-alcoves.md
+++ b/website/src/content/docs/self-hosting/deploying-alcoves.md
@@ -90,7 +90,7 @@ The backend image bundles all runtime dependencies for CPU-only ML inference:
 
 - **libvips** — image transforms, thumbnails, and proxy resizing
 - **ffmpeg** — video transcoding, thumbnail extraction, and audio waveform generation
-- **ONNX Runtime v1.25.0** — face detection/recognition and COCO object detection
+- **ONNX Runtime v1.26.0** — face detection/recognition and COCO object detection
 - **whisper.cpp** — speech-to-text transcription (AVX/AVX2/FMA baseline; no AVX-512 requirement)
 
 :::note


### PR DESCRIPTION
## What

Upgrades the ONNX stack to the latest releases, keeping the Go binding and the native runtime in sync:

- `github.com/yalue/onnxruntime_go`: **v1.30.1 → v1.31.0**
- ONNX Runtime native library: **1.25.0 → 1.26.0**

`onnxruntime_go` v1.31.0 vendors `ORT_API_VERSION 26` and its README pins ORT 1.26.0, so the two latest releases are a matched pair. A binding↔runtime API mismatch silently breaks all face/object/audio inference at runtime (the failure mode behind #554), so both move together.

## Changes

- `backend/go.mod` / `backend/go.sum` — binding bumped via `go get` + `go mod tidy`
- `Dockerfile`, `backend/Dockerfile` — ORT download → 1.26.0
- `.github/workflows/ci.yml` — `ONNX_VERSION=1.26.0` + API-v26 comment
- Docs: `architecture/ml-models-runtime.md`, `self-hosting/deploying-alcoves.md`, `testdata/README.md`

## Verification

Built the backend image from the new Dockerfile and ran the real-inference suites **inside it** against the actual 1.26.0 library:

- Docker CGO build: exit 0 — v1.31.0 compiles and links against ORT 1.26.0
- `objectdetection` real-inference: **PASS** — YOLO26x loaded, correct labels detected
- `facedetection` real-inference: **PASS** — detection + recognition models loaded, face found (conf 0.688), embeddings sane (same-person cosine 0.982 / different 0.166)

No `Error setting ORT API base` / API-version errors — ONNX initializes cleanly on API v26.
