### PR TITLE
feat(image-proxy): hourly variant pre-warm, shared variant registry, named queues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,16 @@ ALCOVES_OAUTH_GOOGLE_CLIENT_ID=
 ALCOVES_OAUTH_GOOGLE_CLIENT_SECRET=
 
 # =============================================================================
+# Image proxy (optional)
+# =============================================================================
+
+# Hourly background job that pre-generates every image-proxy cache variant for
+# each image, so the first view is a warm-cache hit instead of a blocking
+# transform. Set to "false" to disable on constrained hosts that prefer
+# on-demand transforms. Default: enabled.
+# ALCOVES_IMAGE_PROXY_PREWARM_ENABLED=true
+
+# =============================================================================
 # Face recognition tuning (optional)
 # =============================================================================
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/alcoves/alcoves-backend/internal/mcpserver"
 	"github.com/alcoves/alcoves-backend/internal/middleware"
 	"github.com/alcoves/alcoves-backend/internal/models"
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/version"
 	"github.com/hibiken/asynq"
 
@@ -194,23 +195,31 @@ func main() {
 	hashSvc := filehash.NewService(db, storageSvc, asynqClient)
 
 	// Image proxy service — cache lookup, Redis pub/sub signaling, queued processing.
-	imgSvc := imageproxy.NewService(storageSvc, asynqClient, asynqRedisOpt, imageproxy.NewVipsProcessor())
+	// The processor is shared with the pre-warm service below so both the request
+	// path and the maintenance backfill transform identically.
+	imgProcessor := imageproxy.NewVipsProcessor()
+	imgSvc := imageproxy.NewService(storageSvc, asynqClient, asynqRedisOpt, imgProcessor)
+
+	// Image proxy pre-warm service — the hourly maintenance backfill that
+	// generates every image-proxy Variant for each image so the first request is
+	// a warm-cache hit. Runs on the low-priority maintenance queue.
+	imgPrewarmSvc := imageproxy.NewPrewarmService(db, storageSvc, imgProcessor, asynqClient)
 
 	// Start asynq worker if mode is "all" or "worker"
 	var asynqServer *asynq.Server
 	if cfg.Mode == "all" || cfg.Mode == "worker" {
 		asynqServer = asynq.NewServer(asynqRedisOpt, asynq.Config{
 			Concurrency: 8,
-			// imageproxy gets highest priority so API handlers aren't kept waiting;
-			// default queue handles face/object detection and video transcoding.
-			Queues: map[string]int{
-				imageproxy.ImageProxyQueue: 10,
-				"default":                  1,
-			},
+			// Queue weights come from the single source of truth in the queues
+			// package: imageproxy (interactive) ≫ default (batch ML/video) ≫
+			// maintenance (background cache pre-warm), so latency-sensitive work
+			// is never starved by a large maintenance backfill.
+			Queues: queues.Priorities,
 		})
 
 		mux := asynq.NewServeMux()
 		mux.HandleFunc(imageproxy.TaskTypeImageProxy, imgSvc.NewTaskHandler().ProcessTask)
+		mux.HandleFunc(imageproxy.TaskTypePrewarm, imgPrewarmSvc.NewTaskHandler().ProcessTask)
 		mux.HandleFunc(facedetection.TaskTypeFaceDetect, faceSvc.NewTaskHandler().ProcessTask)
 		mux.HandleFunc(objectdetection.TaskTypeObjectDetect, objSvc.NewTaskHandler().ProcessTask)
 		videoTaskHandler := videoSvc.NewTaskHandler()
@@ -234,6 +243,16 @@ func main() {
 		// media files that have never been extracted, giving up after 3 failed
 		// attempts so a permanently-broken file is never re-queued forever.
 		metadata.StartMaintenance(context.Background(), db, metadataSvc)
+
+		// Hourly image-proxy pre-warm: generate every cache variant for each
+		// image so the first request is a warm-cache hit. Same 3-strike cap so a
+		// corrupted image is dropped after 3 attempts. Gated by config so
+		// constrained hosts can opt out.
+		if cfg.ImageProxyPrewarmEnabled {
+			imageproxy.StartPrewarmMaintenance(context.Background(), db, imgPrewarmSvc)
+		} else {
+			log.Println("image:prewarm — disabled via ALCOVES_IMAGE_PROXY_PREWARM_ENABLED=false")
+		}
 	}
 
 	// Echo setup

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -71,6 +71,12 @@ type Config struct {
 	ObjectDetectionMaxDets   int
 	ObjectDetectionNMSThresh float64
 
+	// ImageProxyPrewarmEnabled gates the hourly background job that generates
+	// every image-proxy cache variant for each image (default on). Set
+	// ALCOVES_IMAGE_PROXY_PREWARM_ENABLED=false to disable on constrained hosts
+	// where on-demand transforms are preferred over eager cache warming.
+	ImageProxyPrewarmEnabled bool
+
 	// Transcription (whisper.cpp)
 	WhisperBinaryPath   string
 	WhisperModel        string
@@ -174,6 +180,9 @@ func Load() (*Config, error) {
 		ObjectDetectionMinScore:  objMinScore,
 		ObjectDetectionMaxDets:   objMaxDets,
 		ObjectDetectionNMSThresh: objNMSThresh,
+
+		// Default on; only an explicit "false" disables pre-warming.
+		ImageProxyPrewarmEnabled: getEnv("ALCOVES_IMAGE_PROXY_PREWARM_ENABLED", "true") != "false",
 
 		WhisperBinaryPath: getEnv("ALCOVES_WHISPER_BINARY", "whisper-cli"),
 		WhisperModel:      getEnv("ALCOVES_WHISPER_MODEL", "large-v3"),

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -140,6 +140,10 @@ type File struct {
 	GpsLon                   *float64   `gorm:"column:gps_lon;type:double precision" json:"gpsLon"`
 	CameraMake               *string    `gorm:"column:camera_make;type:text" json:"cameraMake"`
 	CameraModel              *string    `gorm:"column:camera_model;type:text" json:"cameraModel"`
+	ImageProxyStatus         *string    `gorm:"column:image_proxy_status;type:text" json:"imageProxyStatus"`
+	ImageProxyError          *string    `gorm:"column:image_proxy_error;type:text" json:"imageProxyError"`
+	ImageProxyAttempts       int        `gorm:"column:image_proxy_attempts;type:integer;not null;default:0" json:"imageProxyAttempts"`
+	ImageProxyWarmedVersion  *int       `gorm:"column:image_proxy_warmed_version;type:integer" json:"imageProxyWarmedVersion"`
 	ThumbnailFileID          *uuid.UUID `gorm:"column:thumbnail_file_id;type:uuid" json:"thumbnailFileId"`
 	SourceFileID             *uuid.UUID `gorm:"column:source_file_id;type:uuid" json:"sourceFileId"`
 	OriginalCreatedAt        *time.Time `gorm:"column:original_created_at" json:"originalCreatedAt"`

--- a/backend/internal/queues/queues.go
+++ b/backend/internal/queues/queues.go
@@ -1,0 +1,40 @@
+// Package queues is the single source of truth for the named Asynq queues used
+// across Alcoves. Each logical class of background work routes to its own queue
+// so that latency-sensitive work (interactive image transforms) is never stuck
+// behind heavy batch work (ML inference, video transcode) or low-priority
+// maintenance (cache pre-warming).
+//
+// To add a queue: add a constant here, give it a weight in Priorities, and
+// register its handler(s) in cmd/server/main.go. The worker's asynq.Config
+// reads Priorities directly so a new queue is picked up in one place.
+package queues
+
+// Named queues. The string values are the on-the-wire queue names stored in
+// Redis; do not rename them without a migration plan for in-flight tasks.
+const (
+	// Default carries general async work: hashing, metadata/EXIF, waveforms,
+	// face/object detection, audio detection, transcription, video transcode,
+	// and moment export.
+	Default = "default"
+
+	// ImageProxy carries interactive, on-demand image transforms. A user is
+	// usually blocked on these (a thumbnail is rendering), so it gets the
+	// highest weight.
+	ImageProxy = "imageproxy"
+
+	// Maintenance carries low-priority background upkeep that no user is
+	// waiting on — currently the hourly image-proxy variant pre-warm. Lowest
+	// weight so a large backfill batch can never starve interactive transforms
+	// or the default queue.
+	Maintenance = "maintenance"
+)
+
+// Priorities is the asynq queue-weight map consumed by the worker in
+// cmd/server/main.go. Higher weight = a larger share of worker attention.
+// ImageProxy ≫ Default ≫ Maintenance encodes "users first, batch second,
+// upkeep last".
+var Priorities = map[string]int{
+	ImageProxy:  10,
+	Default:     3,
+	Maintenance: 1,
+}

--- a/backend/internal/services/imageproxy/maintenance.go
+++ b/backend/internal/services/imageproxy/maintenance.go
@@ -1,0 +1,121 @@
+package imageproxy
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/alcoves/alcoves-backend/internal/models"
+)
+
+const (
+	// prewarmInterval is how often the pre-warm backfill scan runs. The product
+	// requirement is hourly: heavy enough work that more frequent passes would
+	// waste CPU, infrequent enough that a freshly imported library is fully
+	// warm within a day.
+	prewarmInterval = 1 * time.Hour
+	// prewarmBatch bounds how many files a single pass enqueues so the
+	// maintenance queue (and Redis) is never flooded; the rest drain on later
+	// passes.
+	prewarmBatch = 500
+	// maxPrewarmAttempts is the 3-strike cap: a file whose variants fail to
+	// generate this many times (a corrupted/unsupported image) is dropped from
+	// the scan and never re-queued. This is what stops a job that "fails every
+	// time" from running more than 3 times across maintenance passes.
+	maxPrewarmAttempts = 3
+	// prewarmStuckThreshold lets a file stuck in "queued"/"processing" longer
+	// than this be re-selected, recovering work orphaned by a crashed worker.
+	prewarmStuckThreshold = 15 * time.Minute
+)
+
+// pendingPrewarmFile is the minimal projection the scan needs to enqueue work;
+// the worker re-loads the full row (with source dimensions) when it runs.
+type pendingPrewarmFile struct {
+	ID        string `gorm:"column:id"`
+	LibraryID string `gorm:"column:library_id"`
+}
+
+// StartPrewarmMaintenance launches the hourly background loop that generates
+// every image-proxy Variant for images that have not been warmed yet. It runs
+// only on worker/all nodes and exits when ctx is cancelled. An immediate first
+// pass runs at boot so existing libraries start warming without waiting an hour.
+// If pre-warming is disabled (no processor wired up) the loop is a no-op.
+func StartPrewarmMaintenance(ctx context.Context, db *gorm.DB, svc *PrewarmService) {
+	if svc == nil || !svc.Enabled() {
+		log.Println("image:prewarm — maintenance disabled (no transform processor); skipping")
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(prewarmInterval)
+		defer ticker.Stop()
+
+		runPrewarmPass(db, svc)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				runPrewarmPass(db, svc)
+			}
+		}
+	}()
+}
+
+// scanPendingPrewarm selects up to `limit` live image files that have not been
+// warmed at the current VariantsVersion, are under the 3-strike cap, and are not
+// already queued/processing (unless stuck past prewarmStuckThreshold).
+func scanPendingPrewarm(db *gorm.DB, limit int) ([]pendingPrewarmFile, error) {
+	var rows []pendingPrewarmFile
+	err := db.Raw(`
+		SELECT id, library_id FROM files
+		WHERE image_proxy_warmed_version IS NULL
+		  AND image_proxy_attempts < ?
+		  AND trashed_at IS NULL
+		  AND mime_type LIKE 'image/%'
+		  AND (
+		        image_proxy_status IS NULL
+		        OR image_proxy_status NOT IN ('queued', 'processing')
+		        OR updated_at < NOW() - ? * INTERVAL '1 second'
+		  )
+		ORDER BY created_at DESC
+		LIMIT ?
+	`, maxPrewarmAttempts, int(prewarmStuckThreshold.Seconds()), limit).Scan(&rows).Error
+	return rows, err
+}
+
+// runPrewarmPass selects a bounded batch of un-warmed image files, marks them
+// queued (so the next pass skips them and the stuck-recovery clock starts), and
+// enqueues a pre-warm task for each.
+func runPrewarmPass(db *gorm.DB, svc *PrewarmService) {
+	rows, err := scanPendingPrewarm(db, prewarmBatch)
+	if err != nil {
+		log.Printf("image:prewarm maintenance: scan failed: %v", err)
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+
+	ids := make([]string, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.ID)
+	}
+
+	if err := db.Model(&models.File{}).Where("id IN ?", ids).
+		Update("image_proxy_status", "queued").Error; err != nil {
+		log.Printf("image:prewarm maintenance: failed to mark %d file(s) queued: %v", len(ids), err)
+		return
+	}
+
+	enqueued := 0
+	for _, r := range rows {
+		if err := svc.EnqueuePrewarm(r.LibraryID, r.ID); err != nil {
+			log.Printf("image:prewarm maintenance: enqueue failed for %s: %v", r.ID, err)
+			continue
+		}
+		enqueued++
+	}
+	log.Printf("image:prewarm maintenance: enqueued %d/%d image file(s) for variant pre-warm", enqueued, len(rows))
+}

--- a/backend/internal/services/imageproxy/prewarm.go
+++ b/backend/internal/services/imageproxy/prewarm.go
@@ -1,0 +1,95 @@
+package imageproxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"gorm.io/gorm"
+
+	"github.com/alcoves/alcoves-backend/internal/queues"
+	"github.com/alcoves/alcoves-backend/internal/services/storage"
+)
+
+// TaskTypePrewarm is the asynq task type for the background job that generates
+// every image-proxy Variant for a single file and writes them to the cache, so
+// the first real request is a warm-cache hit instead of a blocking transform.
+const TaskTypePrewarm = "image:prewarm"
+
+const (
+	// prewarmCompletedRetention keeps a finished pre-warm task visible in the
+	// admin dashboard briefly. These are high-volume and uninteresting once
+	// done, so retention is short.
+	prewarmCompletedRetention = 10 * time.Minute
+	// prewarmUniqueTTL deduplicates concurrent enqueues of the same file within
+	// a maintenance pass. It is well under the 1-hour maintenance interval so a
+	// file that still needs warming is re-enqueued on the next pass.
+	prewarmUniqueTTL = 50 * time.Minute
+)
+
+// PrewarmPayload is the asynq payload for a pre-warm task.
+type PrewarmPayload struct {
+	LibraryID string `json:"libraryId"`
+	FileID    string `json:"fileId"`
+}
+
+// PrewarmService owns enqueuing image-proxy variant pre-warm work. Unlike the
+// request-path Service it needs DB access (to read source dimensions and track
+// the 3-strike attempt counter), so it is a distinct type wired with its own
+// dependencies.
+type PrewarmService struct {
+	db          *gorm.DB
+	storageSvc  *storage.Service
+	processor   Processor
+	asynqClient *asynq.Client
+}
+
+// NewPrewarmService constructs the pre-warm service. processor may be nil (the
+// request-path Service serves originals when no processor is wired up); in that
+// case Enabled reports false and the maintenance loop is a no-op.
+func NewPrewarmService(db *gorm.DB, storageSvc *storage.Service, processor Processor, asynqClient *asynq.Client) *PrewarmService {
+	return &PrewarmService{db: db, storageSvc: storageSvc, processor: processor, asynqClient: asynqClient}
+}
+
+// Enabled reports whether pre-warming can run. Without a processor there is no
+// way to transform images (e.g. a build without libvips), so the maintenance
+// loop should not start.
+func (s *PrewarmService) Enabled() bool {
+	return s.processor != nil && s.asynqClient != nil
+}
+
+// NewPrewarmTask builds the asynq task for a single file's pre-warm.
+func NewPrewarmTask(libraryID, fileID string) (*asynq.Task, error) {
+	payload, err := json.Marshal(PrewarmPayload{LibraryID: libraryID, FileID: fileID})
+	if err != nil {
+		return nil, err
+	}
+	return asynq.NewTask(TaskTypePrewarm, payload), nil
+}
+
+// EnqueuePrewarm queues variant pre-warming for one file on the low-priority
+// maintenance queue. MaxRetry is 0: the cross-pass attempt counter in the DB
+// (image_proxy_attempts, capped at maxPrewarmAttempts) is the real 3-strike
+// guard, so a single failed run is simply retried by the next hourly pass —
+// never asynq's 25-retry default.
+func (s *PrewarmService) EnqueuePrewarm(libraryID, fileID string) error {
+	task, err := NewPrewarmTask(libraryID, fileID)
+	if err != nil {
+		return fmt.Errorf("failed to create prewarm task: %w", err)
+	}
+	if _, err := s.asynqClient.Enqueue(task,
+		asynq.Queue(queues.Maintenance),
+		asynq.MaxRetry(0),
+		asynq.Unique(prewarmUniqueTTL),
+		asynq.Retention(prewarmCompletedRetention),
+	); err != nil {
+		return fmt.Errorf("failed to enqueue prewarm task: %w", err)
+	}
+	return nil
+}
+
+// NewTaskHandler returns the asynq handler for image:prewarm tasks.
+func (s *PrewarmService) NewTaskHandler() *PrewarmTaskHandler {
+	return &PrewarmTaskHandler{db: s.db, storageSvc: s.storageSvc, processor: s.processor}
+}

--- a/backend/internal/services/imageproxy/prewarm_test.go
+++ b/backend/internal/services/imageproxy/prewarm_test.go
@@ -1,0 +1,316 @@
+package imageproxy
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/hibiken/asynq"
+	"gorm.io/gorm"
+
+	"github.com/alcoves/alcoves-backend/internal/models"
+	"github.com/alcoves/alcoves-backend/internal/queues"
+	"github.com/alcoves/alcoves-backend/internal/services/storage"
+	"github.com/alcoves/alcoves-backend/internal/testsupport"
+)
+
+// fakeProcessor records call counts and returns canned output (or an error to
+// simulate a corrupt/unsupported source).
+type fakeProcessor struct {
+	out   []byte
+	err   error
+	calls int
+}
+
+func (p *fakeProcessor) Transform(_ []byte, opts TransformOptions) ([]byte, string, error) {
+	p.calls++
+	if p.err != nil {
+		return nil, "", p.err
+	}
+	return p.out, MIMEForOpts(opts), nil
+}
+
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }
+func timePtr() *time.Time     { now := time.Now(); return &now }
+
+// setupPrewarmDB scopes the prewarm tests to their own PostgreSQL schema so the
+// package's GLOBAL scanPendingPrewarm query (no library filter) never sees rows
+// from other packages running concurrently under `go test ./...`.
+func setupPrewarmDB(t *testing.T) (*gorm.DB, uuid.UUID) {
+	t.Helper()
+	db := testsupport.OpenSchema(t, "svc_imageproxy")
+	if err := db.AutoMigrate(&models.User{}, &models.Library{}, &models.File{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	db.Exec("DELETE FROM files")
+	db.Exec("DELETE FROM libraries")
+	db.Exec("DELETE FROM users")
+
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Email: userID.String()[:8] + "@t.com", DisplayName: "U", Role: "owner"})
+	libID := uuid.New()
+	db.Create(&models.Library{ID: libID, Name: "L", OwnerID: userID})
+	return db, libID
+}
+
+func newStorage(t *testing.T) *storage.Service {
+	t.Helper()
+	dir := t.TempDir()
+	driver := storage.NewLocalDriver(
+		filepath.Join(dir, "files"),
+		filepath.Join(dir, "avatars"),
+		filepath.Join(dir, "cache"),
+	)
+	s := storage.NewService(driver)
+	if err := s.EnsureReady(); err != nil {
+		t.Fatalf("storage setup: %v", err)
+	}
+	return s
+}
+
+// TestPrewarmHandler_GeneratesAllVariants is the happy path: a healthy image
+// gets every Variant written to the cache and is marked warmed at the current
+// version with a clean strike counter.
+func TestPrewarmHandler_GeneratesAllVariants(t *testing.T) {
+	db, libID := setupPrewarmDB(t)
+	st := newStorage(t)
+	proc := &fakeProcessor{out: []byte("transformed")}
+
+	w, h := 4000, 3000
+	file := models.File{LibraryID: libID, Name: "p.jpg", MimeType: "image/jpeg", Size: 1, Width: &w, Height: &h}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := st.StoreFile(libID.String(), file.ID.String(), []byte("source-bytes")); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewPrewarmTaskHandler(db, st, proc)
+	if err := handler.run(libID.String(), file.ID.String()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	for _, v := range Variants {
+		key := TransformCacheKey(libID.String(), file.ID.String(), v.Resolve(file.Width, file.Height))
+		if ok, _ := st.CacheExists(key); !ok {
+			t.Errorf("variant %q not written to cache (%s)", v.Name, key)
+		}
+	}
+	if proc.calls != len(Variants) {
+		t.Errorf("processor called %d times, want %d (one per variant)", proc.calls, len(Variants))
+	}
+
+	var got models.File
+	db.First(&got, "id = ?", file.ID)
+	if got.ImageProxyWarmedVersion == nil || *got.ImageProxyWarmedVersion != VariantsVersion {
+		t.Errorf("warmed_version = %v, want %d", got.ImageProxyWarmedVersion, VariantsVersion)
+	}
+	if got.ImageProxyStatus == nil || *got.ImageProxyStatus != "ready" {
+		t.Errorf("status = %v, want ready", got.ImageProxyStatus)
+	}
+	if got.ImageProxyAttempts != 0 {
+		t.Errorf("attempts = %d, want 0", got.ImageProxyAttempts)
+	}
+}
+
+// TestPrewarmHandler_SkipsCachedVariants proves idempotency: a variant already
+// in the cache is not regenerated or overwritten.
+func TestPrewarmHandler_SkipsCachedVariants(t *testing.T) {
+	db, libID := setupPrewarmDB(t)
+	st := newStorage(t)
+	proc := &fakeProcessor{out: []byte("transformed")}
+
+	file := models.File{LibraryID: libID, Name: "p.jpg", MimeType: "image/jpeg", Size: 1}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := st.StoreFile(libID.String(), file.ID.String(), []byte("source-bytes")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate the first variant's cache as if a real request had filled it.
+	v0 := Variants[0]
+	key0 := TransformCacheKey(libID.String(), file.ID.String(), v0.Resolve(file.Width, file.Height))
+	if err := st.StoreCacheBuffer(key0, []byte("preexisting")); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewPrewarmTaskHandler(db, st, proc)
+	if err := handler.run(libID.String(), file.ID.String()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if proc.calls != len(Variants)-1 {
+		t.Errorf("processor called %d times, want %d (cached variant skipped)", proc.calls, len(Variants)-1)
+	}
+	data, err := st.ReadCacheBuffer(key0)
+	if err != nil || string(data) != "preexisting" {
+		t.Errorf("pre-existing variant was overwritten: %q (%v)", data, err)
+	}
+}
+
+// TestPrewarmHandler_CorruptFileStrikesOutAfterThree is the core requirement: a
+// file whose variants fail to generate every time runs at most 3 times. Each
+// failed run increments the strike counter; once it hits the cap the scan drops
+// the file so no further pass enqueues it.
+func TestPrewarmHandler_CorruptFileStrikesOutAfterThree(t *testing.T) {
+	db, libID := setupPrewarmDB(t)
+	st := newStorage(t)
+	proc := &fakeProcessor{err: errors.New("not a valid image")}
+
+	file := models.File{LibraryID: libID, Name: "corrupt.jpg", MimeType: "image/jpeg", Size: 1}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := st.StoreFile(libID.String(), file.ID.String(), []byte("garbage")); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewPrewarmTaskHandler(db, st, proc)
+	for i := 1; i <= maxPrewarmAttempts; i++ {
+		if err := handler.run(libID.String(), file.ID.String()); err == nil {
+			t.Fatalf("attempt %d: expected a transform error", i)
+		}
+		var got models.File
+		db.First(&got, "id = ?", file.ID)
+		if got.ImageProxyAttempts != i {
+			t.Fatalf("after attempt %d, attempts = %d, want %d", i, got.ImageProxyAttempts, i)
+		}
+		if got.ImageProxyWarmedVersion != nil {
+			t.Fatalf("warmed_version should stay nil while failing, got %v", got.ImageProxyWarmedVersion)
+		}
+	}
+
+	// At the cap the maintenance scan must no longer select it — i.e. it will
+	// never run a 4th time.
+	rows, err := scanPendingPrewarm(db, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range rows {
+		if r.ID == file.ID.String() {
+			t.Fatalf("file at the %d-strike cap must be excluded from the scan", maxPrewarmAttempts)
+		}
+	}
+}
+
+// TestPrewarmHandler_TransientFailureDoesNotStrike verifies an infrastructure
+// failure (source unreadable from storage) does NOT burn a strike, so a transient
+// outage can't permanently sideline a healthy file.
+func TestPrewarmHandler_TransientFailureDoesNotStrike(t *testing.T) {
+	db, libID := setupPrewarmDB(t)
+	st := newStorage(t)
+	proc := &fakeProcessor{out: []byte("transformed")}
+
+	// Create the row but DO NOT store source bytes → ReadFileBuffer fails.
+	file := models.File{LibraryID: libID, Name: "missing.jpg", MimeType: "image/jpeg", Size: 1}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewPrewarmTaskHandler(db, st, proc)
+	if err := handler.run(libID.String(), file.ID.String()); err == nil {
+		t.Fatal("expected a transient read error")
+	}
+	if proc.calls != 0 {
+		t.Errorf("processor should not be called when the source can't be read, got %d", proc.calls)
+	}
+
+	var got models.File
+	db.First(&got, "id = ?", file.ID)
+	if got.ImageProxyAttempts != 0 {
+		t.Errorf("transient failure must not increment attempts, got %d", got.ImageProxyAttempts)
+	}
+}
+
+// TestScanPendingPrewarm pins exactly which files the hourly scan selects.
+func TestScanPendingPrewarm(t *testing.T) {
+	db, libID := setupPrewarmDB(t)
+
+	mk := func(name, mime string, f models.File) uuid.UUID {
+		f.LibraryID = libID
+		f.Name = name
+		f.MimeType = mime
+		f.Size = 1
+		if err := db.Create(&f).Error; err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+		return f.ID
+	}
+
+	// Eligible.
+	wantPending := mk("pending.jpg", "image/jpeg", models.File{})
+	wantRetry := mk("failed.jpg", "image/jpeg", models.File{ImageProxyAttempts: 1, ImageProxyStatus: strPtr("failed")})
+	// Derived video-thumbnail images ARE warmed (shown in grid/search/timeline),
+	// unlike the metadata scan which skips derived files.
+	derivedSrc := uuid.New()
+	wantDerived := mk("thumb.webp", "image/webp", models.File{SourceFileID: &derivedSrc})
+
+	// Excluded.
+	mk("exhausted.jpg", "image/jpeg", models.File{ImageProxyAttempts: maxPrewarmAttempts})        // 3-strike cap
+	mk("warmed.jpg", "image/jpeg", models.File{ImageProxyWarmedVersion: intPtr(VariantsVersion)}) // already warmed
+	mk("video.mp4", "video/mp4", models.File{})                                                   // not an image
+	mk("inflight.jpg", "image/jpeg", models.File{ImageProxyStatus: strPtr("queued")})             // in flight (fresh)
+	mk("trashed.jpg", "image/jpeg", models.File{TrashedAt: timePtr()})                            // trashed
+
+	rows, err := scanPendingPrewarm(db, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, r := range rows {
+		got[r.ID] = true
+	}
+	if len(got) != 3 || !got[wantPending.String()] || !got[wantRetry.String()] || !got[wantDerived.String()] {
+		t.Fatalf("scan returned %d rows %v, want exactly {%s, %s, %s}", len(rows), got, wantPending, wantRetry, wantDerived)
+	}
+}
+
+// TestEnqueuePrewarm_RoutesToMaintenanceQueue verifies the logical queue
+// separation: pre-warm tasks land on the low-priority maintenance queue with no
+// asynq-level retries (the DB strike counter is the real cap).
+func TestEnqueuePrewarm_RoutesToMaintenanceQueue(t *testing.T) {
+	mr := miniredis.RunT(t)
+	opt := asynq.RedisClientOpt{Addr: mr.Addr()}
+	client := asynq.NewClient(opt)
+	defer client.Close()
+
+	svc := NewPrewarmService(nil, nil, &fakeProcessor{out: []byte("x")}, client)
+	if err := svc.EnqueuePrewarm("lib", "file"); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	insp := asynq.NewInspector(opt)
+	defer insp.Close()
+	tasks, err := insp.ListPendingTasks(queues.Maintenance)
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("want 1 pending task on %q, got %d", queues.Maintenance, len(tasks))
+	}
+	if tasks[0].Type != TaskTypePrewarm {
+		t.Errorf("task type = %q, want %q", tasks[0].Type, TaskTypePrewarm)
+	}
+	if tasks[0].MaxRetry != 0 {
+		t.Errorf("max retry = %d, want 0 (DB strike counter is the cap)", tasks[0].MaxRetry)
+	}
+}
+
+// TestPrewarmEnabled gates the maintenance loop on having a usable transform
+// backend + queue client.
+func TestPrewarmEnabled(t *testing.T) {
+	if NewPrewarmService(nil, nil, nil, nil).Enabled() {
+		t.Error("no processor/client should report disabled")
+	}
+	mr := miniredis.RunT(t)
+	client := asynq.NewClient(asynq.RedisClientOpt{Addr: mr.Addr()})
+	defer client.Close()
+	if !NewPrewarmService(nil, nil, &fakeProcessor{}, client).Enabled() {
+		t.Error("processor + client should report enabled")
+	}
+}

--- a/backend/internal/services/imageproxy/prewarm_worker.go
+++ b/backend/internal/services/imageproxy/prewarm_worker.go
@@ -1,0 +1,155 @@
+package imageproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hibiken/asynq"
+	"gorm.io/gorm"
+
+	"github.com/alcoves/alcoves-backend/internal/models"
+	"github.com/alcoves/alcoves-backend/internal/services/storage"
+)
+
+// PrewarmTaskHandler processes image:prewarm tasks: it generates every Variant
+// for one file and writes them to the transform cache, so the first real
+// request is a warm-cache hit. It is idempotent — already-cached variants are
+// skipped — and tracks per-file attempts so a permanently-broken file is
+// dropped after maxPrewarmAttempts strikes (see maintenance.go).
+type PrewarmTaskHandler struct {
+	db         *gorm.DB
+	storageSvc *storage.Service
+	processor  Processor
+}
+
+func NewPrewarmTaskHandler(db *gorm.DB, storageSvc *storage.Service, processor Processor) *PrewarmTaskHandler {
+	return &PrewarmTaskHandler{db: db, storageSvc: storageSvc, processor: processor}
+}
+
+// ProcessTask is the asynq entrypoint.
+func (h *PrewarmTaskHandler) ProcessTask(_ context.Context, t *asynq.Task) error {
+	var p PrewarmPayload
+	if err := json.Unmarshal(t.Payload(), &p); err != nil {
+		return fmt.Errorf("invalid prewarm task payload: %w", err)
+	}
+	return h.run(p.LibraryID, p.FileID)
+}
+
+func (h *PrewarmTaskHandler) run(libraryID, fileID string) error {
+	if h.processor == nil {
+		// No transform backend (e.g. a build without libvips). Nothing to do;
+		// don't burn an attempt — degrade gracefully.
+		return nil
+	}
+
+	var file models.File
+	if err := h.db.Where("id = ? AND library_id = ? AND trashed_at IS NULL", fileID, libraryID).First(&file).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// File deleted/trashed between scan and processing — not a failure.
+			log.Printf("image:prewarm — skipping, file %s not found or trashed", fileID)
+			return nil
+		}
+		return err
+	}
+
+	if !strings.HasPrefix(file.MimeType, "image/") {
+		// The scan only selects images, but guard so a stray enqueue is a no-op
+		// rather than a permanent failure.
+		log.Printf("image:prewarm — skipping non-image file %s (%s)", fileID, file.MimeType)
+		return nil
+	}
+
+	h.setStatus(fileID, "processing", nil)
+
+	// Read the source once and reuse it for every variant.
+	srcData, err := h.storageSvc.ReadFileBuffer(libraryID, fileID)
+	if err != nil {
+		// Storage read failure is infrastructure (disk/S3 blip), not a broken
+		// file — retry on the next pass WITHOUT burning a strike.
+		return h.failTransient(fileID, fmt.Errorf("read source: %w", err))
+	}
+
+	generated := 0
+	for _, v := range Variants {
+		opts := v.Resolve(file.Width, file.Height)
+		cacheKey := TransformCacheKey(libraryID, fileID, opts)
+
+		// Idempotent: a variant already in the cache (warmed earlier, or filled
+		// on-demand by a real request) is left untouched.
+		if exists, _ := h.storageSvc.CacheExists(cacheKey); exists {
+			continue
+		}
+
+		outBytes, _, terr := h.processor.Transform(srcData, opts)
+		if terr != nil {
+			// A transform failure means the source bytes are unreadable by the
+			// image pipeline (corrupt / unsupported) — a genuine per-file
+			// failure that should count toward the 3-strike cap. Every variant
+			// reads the same bytes, so the rest would fail identically; stop.
+			return h.fail(fileID, fmt.Errorf("transform variant %q: %w", v.Name, terr))
+		}
+
+		if err := h.storageSvc.StoreCacheBuffer(cacheKey, outBytes); err != nil {
+			// Cache write failure is infrastructure (disk full / S3) — transient.
+			return h.failTransient(fileID, fmt.Errorf("write cache %s: %w", cacheKey, err))
+		}
+		generated++
+	}
+
+	h.complete(fileID)
+	log.Printf("image:prewarm — done %s/%s (%d generated, %d total variants)", libraryID, fileID, generated, len(Variants))
+	return nil
+}
+
+func (h *PrewarmTaskHandler) setStatus(fileID, status string, errMsg *string) {
+	h.db.Model(&models.File{}).Where("id = ?", fileID).Updates(map[string]interface{}{
+		"image_proxy_status": status,
+		"image_proxy_error":  errMsg,
+	})
+}
+
+// fail records a genuine per-file failure (corrupt/unsupported source): it
+// increments image_proxy_attempts, which the maintenance scan caps at
+// maxPrewarmAttempts so a permanently-broken file is dropped after 3 strikes.
+// The returned error is surfaced to asynq for visibility in the dashboard.
+func (h *PrewarmTaskHandler) fail(fileID string, err error) error {
+	log.Printf("image:prewarm — failed for file %s: %v", fileID, err)
+	msg := err.Error()
+	h.db.Model(&models.File{}).Where("id = ?", fileID).Updates(map[string]interface{}{
+		"image_proxy_status":   "failed",
+		"image_proxy_error":    &msg,
+		"image_proxy_attempts": gorm.Expr("image_proxy_attempts + 1"),
+	})
+	return err
+}
+
+// failTransient records an infrastructure failure (storage read/write error)
+// WITHOUT incrementing the strike counter, so a transient outage can't exhaust
+// the 3-strike cap and permanently sideline a healthy file. The next hourly
+// pass re-selects it.
+func (h *PrewarmTaskHandler) failTransient(fileID string, err error) error {
+	log.Printf("image:prewarm — transient failure for file %s: %v", fileID, err)
+	msg := err.Error()
+	h.db.Model(&models.File{}).Where("id = ?", fileID).Updates(map[string]interface{}{
+		"image_proxy_status": "failed",
+		"image_proxy_error":  &msg,
+	})
+	return err
+}
+
+// complete marks the file fully warmed at the current VariantsVersion and resets
+// the strike counter (a healthy file earns a clean slate). The scan keys on
+// image_proxy_warmed_version IS NULL, so this removes the file from the backlog.
+func (h *PrewarmTaskHandler) complete(fileID string) {
+	version := VariantsVersion
+	h.db.Model(&models.File{}).Where("id = ?", fileID).Updates(map[string]interface{}{
+		"image_proxy_status":         "ready",
+		"image_proxy_error":          nil,
+		"image_proxy_warmed_version": &version,
+		"image_proxy_attempts":       0,
+	})
+}

--- a/backend/internal/services/imageproxy/service.go
+++ b/backend/internal/services/imageproxy/service.go
@@ -12,13 +12,17 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
 
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
 )
 
 const (
 	TaskTypeImageProxy = "image:proxy"
-	ImageProxyQueue    = "imageproxy"
-	transformTimeout   = 30 * time.Second
+	// ImageProxyQueue re-exports the canonical queue name from the queues
+	// package so existing callers keep working; queues.ImageProxy is the
+	// single source of truth.
+	ImageProxyQueue  = queues.ImageProxy
+	transformTimeout = 30 * time.Second
 	// uniqueTTL is the deduplication window for enqueued tasks.
 	// Using Unique (Redis lock with TTL) instead of TaskID means failed/archived
 	// tasks can be re-enqueued once the lock expires, rather than conflicting forever.

--- a/backend/internal/services/imageproxy/variants.go
+++ b/backend/internal/services/imageproxy/variants.go
@@ -1,0 +1,72 @@
+package imageproxy
+
+// VariantsVersion is bumped whenever the Variants registry below changes
+// (a size/quality/format edit, or a new variant). The pre-warm maintenance loop
+// stores the version it warmed each file at (files.image_proxy_warmed_version);
+// bumping this constant — together with a one-line migration that resets
+// image_proxy_warmed_version for affected rows — re-warms every file against the
+// new set without any other code change.
+const VariantsVersion = 1
+
+// Variant describes one named image-proxy transform the app requests. This
+// registry is the SINGLE SOURCE OF TRUTH for every (size, format, quality)
+// combination used anywhere in Alcoves: the frontend builds proxy URLs from the
+// mirror in frontend/shared/image-variants.ts, and the pre-warm maintenance job
+// generates exactly these variants for every image. The two files MUST be kept
+// in lockstep — a drift means the pre-warm warms cache keys the UI never
+// requests (wasted work) or misses keys it does (no warm-cache benefit).
+type Variant struct {
+	// Name is the stable identifier shared with the frontend registry.
+	Name string
+	// MaxWidth / MaxHeight bound the output box (aspect ratio is preserved; the
+	// processor only ever downscales). 0 means "unconstrained on that axis".
+	MaxWidth  int
+	MaxHeight int
+	// Quality is the encoder quality 1-100.
+	Quality int
+	// Format is the output container: "jpeg", "webp", "avif", or "png".
+	Format string
+	// Cap controls how the request dimensions are chosen for a given source:
+	//   - Cap=true  → clamp Max{Width,Height} DOWN to the source's own pixel
+	//     dimensions, so a 500px-wide original is requested at w500 (not w720).
+	//     This keeps the cache key identical to what the frontend asks for, and
+	//     avoids storing an oversized box that the processor would never fill.
+	//   - Cap=false → always request the fixed MaxWidth×MaxHeight box,
+	//     regardless of source size (small fixed-grid thumbnails).
+	// The frontend mirror applies the identical rule, so cache keys match.
+	Cap bool
+}
+
+// Variants is the canonical, ordered list of every image-proxy variant the app
+// uses. Mirrored 1:1 by frontend/shared/image-variants.ts.
+//
+//	search   80×80   q70 jpeg  fixed — search-result avatars (search.vue)
+//	timeline 240×240 q70 webp  fixed — timeline grid (timeline.vue)
+//	face     300×300 q80 jpeg  fixed — people / face grid (people/[personId].vue)
+//	card     720×360 q82 jpeg  capped — library browser cards (LibraryEntryCard.vue)
+//	preview  1920×1080 q90 jpeg capped — full-screen lightbox (FilePreview.vue)
+var Variants = []Variant{
+	{Name: "search", MaxWidth: 80, MaxHeight: 80, Quality: 70, Format: "jpeg", Cap: false},
+	{Name: "timeline", MaxWidth: 240, MaxHeight: 240, Quality: 70, Format: "webp", Cap: false},
+	{Name: "face", MaxWidth: 300, MaxHeight: 300, Quality: 80, Format: "jpeg", Cap: false},
+	{Name: "card", MaxWidth: 720, MaxHeight: 360, Quality: 82, Format: "jpeg", Cap: true},
+	{Name: "preview", MaxWidth: 1920, MaxHeight: 1080, Quality: 90, Format: "jpeg", Cap: true},
+}
+
+// Resolve returns the concrete TransformOptions for this variant against a
+// source image of the given pixel dimensions (pass nil when a dimension is
+// unknown). The resulting cache key (see TransformCacheKey) is exactly the one
+// the frontend requests for the same variant + file, so a pre-warmed entry is a
+// guaranteed cache hit.
+func (v Variant) Resolve(srcWidth, srcHeight *int) TransformOptions {
+	w, h := v.MaxWidth, v.MaxHeight
+	if v.Cap {
+		if srcWidth != nil && *srcWidth > 0 && *srcWidth < w {
+			w = *srcWidth
+		}
+		if srcHeight != nil && *srcHeight > 0 && *srcHeight < h {
+			h = *srcHeight
+		}
+	}
+	return TransformOptions{Width: w, Height: h, Quality: v.Quality, Format: v.Format}
+}

--- a/backend/internal/services/imageproxy/variants_test.go
+++ b/backend/internal/services/imageproxy/variants_test.go
@@ -1,0 +1,80 @@
+package imageproxy_test
+
+import (
+	"testing"
+
+	"github.com/alcoves/alcoves-backend/internal/services/imageproxy"
+)
+
+func iptr(i int) *int { return &i }
+
+// TestVariantResolveCacheKeys is the contract guard for the single source of
+// truth: the cache key each variant resolves to MUST equal exactly what the
+// frontend mirror (frontend/shared/image-variants.ts) requests, or the pre-warm
+// warms keys the UI never asks for. If you change a variant here, change the TS
+// mirror in the same PR.
+func TestVariantResolveCacheKeys(t *testing.T) {
+	byName := map[string]imageproxy.Variant{}
+	for _, v := range imageproxy.Variants {
+		byName[v.Name] = v
+	}
+
+	cases := []struct {
+		variant  string
+		srcW     *int
+		srcH     *int
+		wantKey  string
+		wantMIME string
+	}{
+		// Fixed variants ignore source dimensions entirely.
+		{"search", nil, nil, "lib/file/transforms/w80_h80_q70.jpeg", "image/jpeg"},
+		{"search", iptr(40), iptr(40), "lib/file/transforms/w80_h80_q70.jpeg", "image/jpeg"},
+		{"timeline", iptr(50), iptr(50), "lib/file/transforms/w240_h240_q70.webp", "image/webp"},
+		{"face", nil, nil, "lib/file/transforms/w300_h300_q80.jpeg", "image/jpeg"},
+		// Capped variants clamp down to source size when smaller than the box.
+		{"card", nil, nil, "lib/file/transforms/w720_h360_q82.jpeg", "image/jpeg"},
+		{"card", iptr(5000), iptr(4000), "lib/file/transforms/w720_h360_q82.jpeg", "image/jpeg"},
+		{"card", iptr(500), iptr(400), "lib/file/transforms/w500_h360_q82.jpeg", "image/jpeg"},
+		{"preview", iptr(1000), iptr(800), "lib/file/transforms/w1000_h800_q90.jpeg", "image/jpeg"},
+		{"preview", iptr(4000), iptr(3000), "lib/file/transforms/w1920_h1080_q90.jpeg", "image/jpeg"},
+	}
+
+	for _, c := range cases {
+		v, ok := byName[c.variant]
+		if !ok {
+			t.Fatalf("variant %q missing from registry", c.variant)
+		}
+		opts := v.Resolve(c.srcW, c.srcH)
+		gotKey := imageproxy.TransformCacheKey("lib", "file", opts)
+		if gotKey != c.wantKey {
+			t.Errorf("%s Resolve(%v,%v) key = %q, want %q", c.variant, c.srcW, c.srcH, gotKey, c.wantKey)
+		}
+		if gotMIME := imageproxy.MIMEForOpts(opts); gotMIME != c.wantMIME {
+			t.Errorf("%s mime = %q, want %q", c.variant, gotMIME, c.wantMIME)
+		}
+	}
+}
+
+// TestVariantsRegistryStable pins the exact registry contents so an accidental
+// edit (or a merge that drops a variant) is caught, and so VariantsVersion is
+// bumped deliberately alongside any change.
+func TestVariantsRegistryStable(t *testing.T) {
+	want := []imageproxy.Variant{
+		{Name: "search", MaxWidth: 80, MaxHeight: 80, Quality: 70, Format: "jpeg", Cap: false},
+		{Name: "timeline", MaxWidth: 240, MaxHeight: 240, Quality: 70, Format: "webp", Cap: false},
+		{Name: "face", MaxWidth: 300, MaxHeight: 300, Quality: 80, Format: "jpeg", Cap: false},
+		{Name: "card", MaxWidth: 720, MaxHeight: 360, Quality: 82, Format: "jpeg", Cap: true},
+		{Name: "preview", MaxWidth: 1920, MaxHeight: 1080, Quality: 90, Format: "jpeg", Cap: true},
+	}
+	if len(imageproxy.Variants) != len(want) {
+		t.Fatalf("registry has %d variants, want %d — if intentional, update this test AND bump VariantsVersion AND the TS mirror", len(imageproxy.Variants), len(want))
+	}
+	for i, w := range want {
+		if imageproxy.Variants[i] != w {
+			t.Errorf("variant[%d] = %+v, want %+v", i, imageproxy.Variants[i], w)
+		}
+	}
+	if imageproxy.VariantsVersion < 1 {
+		t.Errorf("VariantsVersion = %d, want >= 1", imageproxy.VariantsVersion)
+	}
+}

--- a/backend/migrations/00022_add_image_proxy_prewarm_fields.sql
+++ b/backend/migrations/00022_add_image_proxy_prewarm_fields.sql
@@ -1,0 +1,44 @@
+-- +goose NO TRANSACTION
+--
+-- This migration builds its index CONCURRENTLY (mirrors 00021), which cannot run
+-- inside a transaction. The ADD COLUMN statements are metadata-only on PG11+
+-- (constant defaults don't rewrite the table), so running them outside a
+-- transaction is safe; every statement is idempotent (IF [NOT] EXISTS) so a
+-- re-run after a mid-migration failure is harmless.
+
+-- +goose Up
+
+-- Image-proxy variant pre-warm job-tracking columns (mirrors the metadata_*
+-- status/attempts pattern). The hourly maintenance loop reads these to decide
+-- which images still need their cache variants generated, and to drop a
+-- permanently-broken file after 3 strikes.
+ALTER TABLE files ADD COLUMN IF NOT EXISTS image_proxy_status TEXT;
+ALTER TABLE files ADD COLUMN IF NOT EXISTS image_proxy_error TEXT;
+-- Failure counter consulted by the maintenance scan: a file whose variants fail
+-- to generate 3 times (e.g. a corrupted image) is dropped from the scan so it
+-- is never re-queued forever.
+ALTER TABLE files ADD COLUMN IF NOT EXISTS image_proxy_attempts INTEGER NOT NULL DEFAULT 0;
+-- The imageproxy.VariantsVersion this row was last fully warmed at. NULL = never
+-- warmed (the pending state the scan selects on). Bumping VariantsVersion in code
+-- and resetting this column to NULL re-warms every file against the new set.
+ALTER TABLE files ADD COLUMN IF NOT EXISTS image_proxy_warmed_version INTEGER;
+
+-- Maintenance pre-warm scan: live image files not yet warmed. The scan is global
+-- (no library filter) and pages newest-first, so the index leads with created_at
+-- DESC to satisfy the ORDER BY ... LIMIT directly; the partial predicate keeps it
+-- tiny as the backlog drains. Unlike the metadata scan we do NOT exclude
+-- source_file_id IS NOT NULL — derived video-thumbnail images are themselves
+-- shown in the grid/search/timeline and need their variants warmed too.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS files_image_proxy_pending_idx
+    ON files (created_at DESC)
+    WHERE image_proxy_warmed_version IS NULL
+      AND trashed_at IS NULL;
+
+-- +goose Down
+
+DROP INDEX CONCURRENTLY IF EXISTS files_image_proxy_pending_idx;
+
+ALTER TABLE files DROP COLUMN IF EXISTS image_proxy_warmed_version;
+ALTER TABLE files DROP COLUMN IF EXISTS image_proxy_attempts;
+ALTER TABLE files DROP COLUMN IF EXISTS image_proxy_error;
+ALTER TABLE files DROP COLUMN IF EXISTS image_proxy_status;

--- a/frontend/app/components/AlcovesImage.vue
+++ b/frontend/app/components/AlcovesImage.vue
@@ -1,19 +1,40 @@
 <script setup lang="ts">
+import {
+  type ImageFormat,
+  type ImageVariantName,
+  type ResolvedTransform,
+  proxyQueryString,
+  resolveVariant,
+} from "~~/shared/image-variants";
+
 interface Props {
   libraryId: string;
   fileId: string;
   alt?: string;
+  /**
+   * Named variant from the shared registry (shared/image-variants.ts). Preferred
+   * over passing raw width/height/quality/format: it keeps every call site
+   * pointing at the single source of truth and guarantees a pre-warm cache hit.
+   */
+  variant?: ImageVariantName;
+  /**
+   * Source image dimensions, used to clamp capped variants (card, preview) down
+   * to the original's size so the cache key matches what the pre-warm job built.
+   * Ignored for fixed variants.
+   */
+  sourceWidth?: number | null;
+  sourceHeight?: number | null;
+  // Explicit overrides. When a variant is set these win over the resolved value;
+  // without a variant they drive the request directly (legacy / ad-hoc usage).
   width?: number;
   height?: number;
-  format?: "jpeg" | "webp" | "avif" | "png";
+  format?: ImageFormat;
   quality?: number;
   class?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   alt: "",
-  format: "jpeg",
-  quality: 80,
 });
 
 const emit = defineEmits<{
@@ -21,26 +42,29 @@ const emit = defineEmits<{
   load: [event: Event];
 }>();
 
-const proxySrc = computed(() => {
-  const params: [string, string][] = [["format", props.format]];
-  if (props.width) params.push(["width", String(props.width)]);
-  if (props.height) params.push(["height", String(props.height)]);
-  if (props.quality) params.push(["quality", String(props.quality)]);
-
-  // Sort for consistent URLs that match server-side cache key ordering
-  params.sort(([a], [b]) => a.localeCompare(b));
-  const query = new URLSearchParams(params).toString();
-
-  return apiUrl(`/api/files/proxy/${props.libraryId}/${props.fileId}?${query}`);
+const resolved = computed<ResolvedTransform>(() => {
+  const base: ResolvedTransform = props.variant
+    ? resolveVariant(props.variant, props.sourceWidth, props.sourceHeight)
+    : { width: 0, height: 0, quality: 80, format: "jpeg" };
+  return {
+    width: props.width ?? base.width,
+    height: props.height ?? base.height,
+    quality: props.quality ?? base.quality,
+    format: props.format ?? base.format,
+  };
 });
+
+const proxySrc = computed(() =>
+  apiUrl(`/api/files/proxy/${props.libraryId}/${props.fileId}?${proxyQueryString(resolved.value)}`),
+);
 </script>
 
 <template>
   <img
     :src="proxySrc"
     :alt="alt"
-    :width="width"
-    :height="height"
+    :width="resolved.width || undefined"
+    :height="resolved.height || undefined"
     :class="$props.class"
     loading="lazy"
     decoding="async"

--- a/frontend/app/components/FilePreview.vue
+++ b/frontend/app/components/FilePreview.vue
@@ -4,6 +4,7 @@ import "vidstack/player/styles/default/layouts/audio.css";
 import "vidstack/player/styles/default/layouts/video.css";
 
 import type { LibraryFile, PlaybackSource, PlaybackSourcesResponse } from "~~/shared/types/api";
+import { proxyQueryString, resolveVariant } from "~~/shared/image-variants";
 import { getMimeIcon } from "~/utils/mime-icons";
 import { apiFetch } from "~/utils/api-fetch";
 import { api } from "~/api";
@@ -322,17 +323,11 @@ watch(
   { immediate: true },
 );
 
-// Preload adjacent images
+// Preload adjacent images. Uses the shared "preview" variant so the lightbox
+// requests exactly the cache key the pre-warm job generated.
 function buildPreviewUrl(file: LibraryFile): string {
-  const w = file.width && file.width < 1920 ? file.width : 1920;
-  const h = file.height && file.height < 1080 ? file.height : 1080;
-  const params = new URLSearchParams([
-    ["format", "jpeg"],
-    ["height", String(h)],
-    ["quality", "90"],
-    ["width", String(w)],
-  ]);
-  return apiUrl(`/api/files/proxy/${props.libraryId}/${file.id}?${params}`);
+  const query = proxyQueryString(resolveVariant("preview", file.width, file.height));
+  return apiUrl(`/api/files/proxy/${props.libraryId}/${file.id}?${query}`);
 }
 
 const previewImageUrl = computed(() => buildPreviewUrl(props.file));

--- a/frontend/app/components/library/LibraryEntriesGrid.vue
+++ b/frontend/app/components/library/LibraryEntriesGrid.vue
@@ -16,8 +16,6 @@ interface Props {
   failedThumbnails: Set<string>;
   isImageFile: (file: LibraryFile) => boolean;
   isSmallImage: (file: LibraryFile) => boolean;
-  cardThumbWidth: (file: LibraryFile) => number;
-  cardThumbHeight: (file: LibraryFile) => number;
 }
 
 const props = defineProps<Props>();
@@ -73,8 +71,6 @@ const fileEntries = computed(() =>
           :failed-thumbnails="failedThumbnails"
           :is-image-file="isImageFile"
           :is-small-image="isSmallImage"
-          :card-thumb-width="cardThumbWidth"
-          :card-thumb-height="cardThumbHeight"
           @row-click="(entry, event) => emit('rowClick', entry, event)"
           @row-double-click="emit('rowDoubleClick', $event)"
           @row-context-menu="(entry, event) => emit('rowContextMenu', entry, event)"
@@ -109,8 +105,6 @@ const fileEntries = computed(() =>
           :failed-thumbnails="failedThumbnails"
           :is-image-file="isImageFile"
           :is-small-image="isSmallImage"
-          :card-thumb-width="cardThumbWidth"
-          :card-thumb-height="cardThumbHeight"
           @row-click="(entry, event) => emit('rowClick', entry, event)"
           @row-double-click="emit('rowDoubleClick', $event)"
           @row-context-menu="(entry, event) => emit('rowContextMenu', entry, event)"

--- a/frontend/app/components/library/LibraryEntryCard.vue
+++ b/frontend/app/components/library/LibraryEntryCard.vue
@@ -18,8 +18,6 @@ interface Props {
   failedThumbnails: Set<string>;
   isImageFile: (file: LibraryFile) => boolean;
   isSmallImage: (file: LibraryFile) => boolean;
-  cardThumbWidth: (file: LibraryFile) => number;
-  cardThumbHeight: (file: LibraryFile) => number;
 }
 
 const props = defineProps<Props>();
@@ -144,10 +142,9 @@ const emit = defineEmits<{
             :library-id="libraryId"
             :file-id="props.entry.thumbnailFileId"
             :alt="props.entry.name"
-            :width="props.cardThumbWidth(props.entry)"
-            :height="props.cardThumbHeight(props.entry)"
-            format="jpeg"
-            :quality="82"
+            variant="card"
+            :source-width="props.entry.width"
+            :source-height="props.entry.height"
             class="w-full h-full object-cover"
             @error="emit('thumbnailError', props.entry.id)"
           />
@@ -177,10 +174,9 @@ const emit = defineEmits<{
           :library-id="libraryId"
           :file-id="props.entry.id"
           :alt="props.entry.name"
-          :width="props.cardThumbWidth(props.entry)"
-          :height="props.cardThumbHeight(props.entry)"
-          format="jpeg"
-          :quality="82"
+          variant="card"
+          :source-width="props.entry.width"
+          :source-height="props.entry.height"
           :class="props.isSmallImage(props.entry) ? 'object-contain' : 'w-full h-full object-cover'"
           @error="emit('thumbnailError', props.entry.id)"
         />

--- a/frontend/app/pages/libraries/[id]/index.vue
+++ b/frontend/app/pages/libraries/[id]/index.vue
@@ -290,16 +290,6 @@ function isSmallImage(file: LibraryFile): boolean {
   return Boolean(file.width && file.height && file.width < 320 && file.height < 160);
 }
 
-function cardThumbWidth(file: LibraryFile): number {
-  if (file.width && file.width < 720) return file.width;
-  return 720;
-}
-
-function cardThumbHeight(file: LibraryFile): number {
-  if (file.height && file.height < 360) return file.height;
-  return 360;
-}
-
 function buildFolderLabel(folder: LibraryFolder, folderMap: Map<string, LibraryFolder>) {
   const parts: string[] = [folder.name];
   let current = folder.parentFolderId;
@@ -1241,8 +1231,6 @@ const emptyStateDescription = computed(() => {
           :failed-thumbnails="failedThumbnails"
           :is-image-file="isImageFile"
           :is-small-image="isSmallImage"
-          :card-thumb-width="cardThumbWidth"
-          :card-thumb-height="cardThumbHeight"
           @row-click="handleRowClick"
           @row-double-click="openEntry"
           @row-context-menu="showContextMenu"

--- a/frontend/app/pages/libraries/[id]/people/[personId].vue
+++ b/frontend/app/pages/libraries/[id]/people/[personId].vue
@@ -182,8 +182,7 @@ watch(
             :library-id="libraryId"
             :file-id="face.fileId"
             :alt="face.fileName"
-            :width="300"
-            :height="300"
+            variant="face"
             class="w-full aspect-square object-cover"
           />
           <div

--- a/frontend/app/pages/libraries/[id]/timeline.vue
+++ b/frontend/app/pages/libraries/[id]/timeline.vue
@@ -152,10 +152,7 @@ onBeforeUnmount(() => {
                 v-if="thumbId(file)"
                 :library-id="libraryId"
                 :file-id="thumbId(file)!"
-                :width="240"
-                :height="240"
-                format="webp"
-                :quality="70"
+                variant="timeline"
                 class="h-full w-full object-cover transition-transform group-hover:scale-105"
               />
               <span v-else class="flex h-full w-full items-center justify-center text-dimmed">

--- a/frontend/app/pages/search.vue
+++ b/frontend/app/pages/search.vue
@@ -215,10 +215,7 @@ async function openPreview(result: GlobalSearchResult) {
                 :library-id="result.libraryId"
                 :file-id="getThumbnailFileId(result)!"
                 :alt="result.name"
-                :width="80"
-                :height="80"
-                format="jpeg"
-                :quality="70"
+                variant="search"
                 class="size-full object-cover"
                 @error="failedThumbnails.add(result.id)"
               />

--- a/frontend/shared/image-variants.ts
+++ b/frontend/shared/image-variants.ts
@@ -1,0 +1,91 @@
+// Single source of truth for every image-proxy transform the app requests.
+//
+// This is the MIRROR of the backend registry in
+// backend/internal/services/imageproxy/variants.go — the two MUST be kept in
+// lockstep. The backend's hourly pre-warm job generates exactly these variants
+// for every image, so each cache key the frontend requests here is a warm-cache
+// hit. A drift means wasted pre-warm work (keys the UI never asks for) or missed
+// warming (keys the UI asks for but the job never generated). When you change a
+// variant, change variants.go in the same PR (and bump its VariantsVersion).
+
+export type ImageFormat = "jpeg" | "webp" | "avif" | "png";
+
+export interface ImageVariant {
+  /** Stable identifier shared with the Go registry. */
+  name: string;
+  /** Output box; aspect ratio is preserved and the source is only downscaled. */
+  maxWidth: number;
+  maxHeight: number;
+  /** Encoder quality 1-100. */
+  quality: number;
+  format: ImageFormat;
+  /**
+   * When true, the requested dimensions are clamped DOWN to the source's own
+   * pixel size (a 500px-wide original is requested at w500, not w720) — matching
+   * Variant.Cap in the backend so the cache keys are identical. When false the
+   * variant always requests the fixed maxWidth×maxHeight box.
+   */
+  cap: boolean;
+}
+
+/**
+ * The canonical variant set. Mirror of imageproxy.Variants (Go).
+ *
+ *  search   80×80     q70 jpeg  fixed  — search-result avatars
+ *  timeline 240×240   q70 webp  fixed  — timeline grid
+ *  face     300×300   q80 jpeg  fixed  — people / face grid
+ *  card     720×360   q82 jpeg  capped — library browser cards
+ *  preview  1920×1080 q90 jpeg  capped — full-screen lightbox
+ */
+export const IMAGE_VARIANTS = {
+  search: { name: "search", maxWidth: 80, maxHeight: 80, quality: 70, format: "jpeg", cap: false },
+  timeline: { name: "timeline", maxWidth: 240, maxHeight: 240, quality: 70, format: "webp", cap: false },
+  face: { name: "face", maxWidth: 300, maxHeight: 300, quality: 80, format: "jpeg", cap: false },
+  card: { name: "card", maxWidth: 720, maxHeight: 360, quality: 82, format: "jpeg", cap: true },
+  preview: { name: "preview", maxWidth: 1920, maxHeight: 1080, quality: 90, format: "jpeg", cap: true },
+} as const satisfies Record<string, ImageVariant>;
+
+export type ImageVariantName = keyof typeof IMAGE_VARIANTS;
+
+export interface ResolvedTransform {
+  width: number;
+  height: number;
+  quality: number;
+  format: ImageFormat;
+}
+
+/**
+ * Resolve a named variant against a source image's pixel dimensions (pass
+ * undefined/null when unknown). The result mirrors Variant.Resolve in Go, so the
+ * resulting cache key matches exactly what the pre-warm job generated.
+ */
+export function resolveVariant(
+  name: ImageVariantName,
+  sourceWidth?: number | null,
+  sourceHeight?: number | null,
+): ResolvedTransform {
+  const v = IMAGE_VARIANTS[name];
+  let width: number = v.maxWidth;
+  let height: number = v.maxHeight;
+  if (v.cap) {
+    if (sourceWidth && sourceWidth > 0 && sourceWidth < width) width = sourceWidth;
+    if (sourceHeight && sourceHeight > 0 && sourceHeight < height) height = sourceHeight;
+  }
+  return { width, height, quality: v.quality, format: v.format };
+}
+
+/**
+ * Build the deterministic, alphabetically-sorted image-proxy query string for a
+ * resolved transform. Sharing one builder across every call site guarantees a
+ * single URL shape (and so a single browser/CDN cache entry) per variant+file.
+ * Zero width/height are omitted (no constraint on that axis), matching the
+ * server's optional query params.
+ */
+export function proxyQueryString(t: ResolvedTransform): string {
+  const params: [string, string][] = [["format", t.format]];
+  if (t.width) params.push(["width", String(t.width)]);
+  if (t.height) params.push(["height", String(t.height)]);
+  if (t.quality) params.push(["quality", String(t.quality)]);
+  params.sort(([a], [b]) => a.localeCompare(b));
+  return new URLSearchParams(params).toString();
+}

--- a/frontend/test/components/AlcovesImage.spec.ts
+++ b/frontend/test/components/AlcovesImage.spec.ts
@@ -54,4 +54,38 @@ describe("AlcovesImage", () => {
     expect(img.attributes("height")).toBe("200");
     expect(img.classes()).toEqual(expect.arrayContaining(["rounded-md", "object-cover"]));
   });
+
+  it("resolves a fixed variant from the shared registry", () => {
+    const wrapper = mount(AlcovesImage, {
+      props: { libraryId: "lib", fileId: "file", variant: "search" },
+    });
+    expect(wrapper.get("img").attributes("src")).toBe(
+      "/api/files/proxy/lib/file?format=jpeg&height=80&quality=70&width=80",
+    );
+  });
+
+  it("clamps a capped variant down to the source dimensions", () => {
+    const wrapper = mount(AlcovesImage, {
+      props: {
+        libraryId: "lib",
+        fileId: "file",
+        variant: "card",
+        sourceWidth: 500,
+        sourceHeight: 400,
+      },
+    });
+    // card box is 720×360; width clamps to the 500px source, height stays 360.
+    expect(wrapper.get("img").attributes("src")).toBe(
+      "/api/files/proxy/lib/file?format=jpeg&height=360&quality=82&width=500",
+    );
+  });
+
+  it("lets explicit props override a variant", () => {
+    const wrapper = mount(AlcovesImage, {
+      props: { libraryId: "lib", fileId: "file", variant: "timeline", quality: 95 },
+    });
+    expect(wrapper.get("img").attributes("src")).toBe(
+      "/api/files/proxy/lib/file?format=webp&height=240&quality=95&width=240",
+    );
+  });
 });

--- a/frontend/test/components/library/LibraryEntriesGrid.emits.spec.ts
+++ b/frontend/test/components/library/LibraryEntriesGrid.emits.spec.ts
@@ -24,8 +24,6 @@ function mountGrid(entries: LibraryEntry[]) {
       failedThumbnails: new Set<string>(),
       isImageFile: () => false,
       isSmallImage: () => false,
-      cardThumbWidth: () => 320,
-      cardThumbHeight: () => 180,
     },
   });
 }

--- a/frontend/test/components/library/LibraryEntriesGrid.spec.ts
+++ b/frontend/test/components/library/LibraryEntriesGrid.spec.ts
@@ -65,8 +65,6 @@ function defaultProps(overrides: Record<string, unknown> = {}) {
     failedThumbnails: new Set<string>(),
     isImageFile: (f: LibraryFile) => f.mimeType.startsWith("image/"),
     isSmallImage: () => false,
-    cardThumbWidth: () => 400,
-    cardThumbHeight: () => 300,
     ...overrides,
   };
 }

--- a/frontend/test/components/library/LibraryEntryCard.spec.ts
+++ b/frontend/test/components/library/LibraryEntryCard.spec.ts
@@ -45,8 +45,6 @@ function mountCard(entry: LibraryEntry, over: Record<string, unknown> = {}) {
       failedThumbnails: new Set<string>(),
       isImageFile: (f: { mimeType: string }) => f.mimeType.startsWith("image/"),
       isSmallImage: () => false,
-      cardThumbWidth: () => 320,
-      cardThumbHeight: () => 180,
       ...over,
     },
   });

--- a/frontend/test/shared/image-variants.spec.ts
+++ b/frontend/test/shared/image-variants.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import {
+  IMAGE_VARIANTS,
+  proxyQueryString,
+  resolveVariant,
+} from "~~/shared/image-variants";
+
+describe("image-variants registry", () => {
+  it("pins the canonical variant set (mirror of imageproxy.Variants in Go)", () => {
+    // If this changes, change backend/internal/services/imageproxy/variants.go
+    // in the same PR and bump its VariantsVersion.
+    expect(IMAGE_VARIANTS).toEqual({
+      search: { name: "search", maxWidth: 80, maxHeight: 80, quality: 70, format: "jpeg", cap: false },
+      timeline: { name: "timeline", maxWidth: 240, maxHeight: 240, quality: 70, format: "webp", cap: false },
+      face: { name: "face", maxWidth: 300, maxHeight: 300, quality: 80, format: "jpeg", cap: false },
+      card: { name: "card", maxWidth: 720, maxHeight: 360, quality: 82, format: "jpeg", cap: true },
+      preview: { name: "preview", maxWidth: 1920, maxHeight: 1080, quality: 90, format: "jpeg", cap: true },
+    });
+  });
+});
+
+describe("resolveVariant", () => {
+  it("returns fixed dimensions for non-capped variants regardless of source size", () => {
+    expect(resolveVariant("search")).toEqual({ width: 80, height: 80, quality: 70, format: "jpeg" });
+    expect(resolveVariant("search", 40, 40)).toEqual({ width: 80, height: 80, quality: 70, format: "jpeg" });
+    expect(resolveVariant("timeline", 10, 10)).toEqual({ width: 240, height: 240, quality: 70, format: "webp" });
+    expect(resolveVariant("face")).toEqual({ width: 300, height: 300, quality: 80, format: "jpeg" });
+  });
+
+  it("clamps capped variants down to the source's own dimensions", () => {
+    // Smaller-than-box source → request the source size (matches the cache key
+    // the pre-warm job built from files.width/height).
+    expect(resolveVariant("card", 500, 400)).toEqual({ width: 500, height: 360, quality: 82, format: "jpeg" });
+    expect(resolveVariant("preview", 1000, 800)).toEqual({ width: 1000, height: 800, quality: 90, format: "jpeg" });
+  });
+
+  it("uses the full box for capped variants when the source is larger or unknown", () => {
+    expect(resolveVariant("card", 5000, 4000)).toEqual({ width: 720, height: 360, quality: 82, format: "jpeg" });
+    expect(resolveVariant("card")).toEqual({ width: 720, height: 360, quality: 82, format: "jpeg" });
+    expect(resolveVariant("card", null, null)).toEqual({ width: 720, height: 360, quality: 82, format: "jpeg" });
+    expect(resolveVariant("preview", 4000, 3000)).toEqual({ width: 1920, height: 1080, quality: 90, format: "jpeg" });
+  });
+});
+
+describe("proxyQueryString", () => {
+  it("emits alphabetically-sorted params", () => {
+    expect(proxyQueryString({ width: 80, height: 80, quality: 70, format: "jpeg" })).toBe(
+      "format=jpeg&height=80&quality=70&width=80",
+    );
+    expect(proxyQueryString({ width: 240, height: 240, quality: 70, format: "webp" })).toBe(
+      "format=webp&height=240&quality=70&width=240",
+    );
+  });
+
+  it("omits zero width/height (no constraint on that axis)", () => {
+    expect(proxyQueryString({ width: 0, height: 0, quality: 80, format: "jpeg" })).toBe(
+      "format=jpeg&quality=80",
+    );
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineVitestConfig({
     include: [
       "test/components/**/*.spec.ts",
       "test/composables/**/*.spec.ts",
+      "test/shared/**/*.spec.ts",
       "test/utils/**/*.spec.ts",
       "test/app/**/*.spec.ts",
       "test/pages/**/*.spec.ts",

--- a/website/src/content/docs/architecture/media-processing-pipeline.md
+++ b/website/src/content/docs/architecture/media-processing-pipeline.md
@@ -24,7 +24,15 @@ This page covers the non-ML media pipeline. AI-driven analysis (face recognition
 - **Asynq job queue** (backed by Dragonfly/Redis) — async task dispatch, deduplication, and retention
 - **Storage service** — unified blob I/O across local-disk and S3 backends, scoped to `Files`, `Avatars`, and `Cache`
 
-Worker processes register with the Asynq mux when the server runs in `all` or `worker` mode (`ALCOVES_MODE`). The image proxy queue runs at higher priority than the default queue so interactive image loads are not starved by background transcodes.
+Worker processes register with the Asynq mux when the server runs in `all` or `worker` mode (`ALCOVES_MODE`). Work is split across three named queues — the single source of truth for queue names and weights is the `internal/queues` package:
+
+| Queue | Weight | Carries |
+|---|---|---|
+| `imageproxy` | 10 | Interactive, on-demand image transforms (a user is blocked on these) |
+| `default` | 3 | Hashing, metadata/EXIF, waveforms, face/object/audio detection, transcription, video transcode, moment export |
+| `maintenance` | 1 | Low-priority background upkeep — currently the hourly image-proxy variant pre-warm |
+
+The weights mean "users first, batch second, upkeep last": a large pre-warm or detection backlog can never starve interactive image loads.
 
 ---
 
@@ -45,6 +53,23 @@ The proxy accepts four query parameters:
 
 Width and height are clamped to 4096 to prevent memory exhaustion from crafted requests against the libvips allocator.
 
+### Variant registry (single source of truth)
+
+Rather than scattering sizes across the UI, every distinct transform the app requests is named once in a shared **variant registry**. The registry is mirrored on both sides of the stack and must be changed in lockstep:
+
+- Backend: `backend/internal/services/imageproxy/variants.go` (`imageproxy.Variants`)
+- Frontend: `frontend/shared/image-variants.ts` (`IMAGE_VARIANTS`)
+
+| Variant | Box | Quality | Format | Sizing | Used by |
+|---|---|---|---|---|---|
+| `search` | 80×80 | 70 | jpeg | fixed | Search-result avatars |
+| `timeline` | 240×240 | 70 | webp | fixed | Timeline grid |
+| `face` | 300×300 | 80 | jpeg | fixed | People / face grid |
+| `card` | 720×360 | 82 | jpeg | capped | Library browser cards |
+| `preview` | 1920×1080 | 90 | jpeg | capped | Full-screen lightbox |
+
+A **capped** variant clamps its box down to the source image's own pixel dimensions (a 500 px-wide original is requested at `w500`, not `w720`), so the cache key matches the source exactly and no oversized box is stored. A **fixed** variant always requests the full box. Both the frontend URL builder (`resolveVariant`) and the backend pre-warm job (`Variant.Resolve`) apply the identical rule, guaranteeing the cache key a request produces is exactly the one the pre-warm job generated. The registry carries a `VariantsVersion`; bumping it (plus a one-line migration that resets `image_proxy_warmed_version`) re-warms every image against the new set.
+
 ### Transform pipeline (libvips)
 
 1. Decode source bytes from storage.
@@ -64,6 +89,16 @@ When a transform derivative is not yet cached, the proxy must coordinate concurr
 5. **Wait** — block up to 30 seconds for the pub/sub signal. An `"ok"` signal reads the result from a transient Redis key first (avoids stale NFS attribute cache), falling back to storage with retries. An `"error"` signal returns immediately without waiting for the timeout.
 
 When Redis is not available (development or test environments), the proxy transforms synchronously and writes directly to cache storage.
+
+### Variant pre-warm (hourly maintenance)
+
+The concurrency model above fills the cache *lazily* — the first viewer of each derivative pays the transform latency. To eliminate that cold-start cost, an **hourly background maintenance loop** (running on `all`/`worker` nodes, gated by `ALCOVES_IMAGE_PROXY_PREWARM_ENABLED`, default on) generates every registry variant for every image ahead of time:
+
+1. **Scan** — a bounded batch (500/pass) of live image files that have not been warmed at the current `VariantsVersion`, are under the 3-strike cap, and are not already in flight (or are stuck past 15 minutes). Derived video-thumbnail images are included; trashed files are not.
+2. **Enqueue** — one `image:prewarm` task per file on the low-priority `maintenance` queue, so the backfill never competes with interactive transforms.
+3. **Generate** — the worker reads the source once and writes any missing variant to cache (already-cached variants are skipped, making the job idempotent), then marks the file warmed.
+
+**Failure handling.** A genuine per-file failure — a corrupted or unsupported source that fails the libvips transform — increments a strike counter (`files.image_proxy_attempts`). After **3 strikes** the scan drops the file permanently, so a job that fails every time runs at most three times rather than being re-queued forever. Infrastructure failures (a storage read/write blip) are recorded *without* burning a strike, so a transient outage can't sideline a healthy file. Tasks carry no asynq-level retries; the database strike counter is the sole cap, applied across maintenance passes.
 
 ### Access control
 

--- a/website/src/content/docs/features/admin-and-job-queue.md
+++ b/website/src/content/docs/features/admin-and-job-queue.md
@@ -131,6 +131,32 @@ is happening in real time and intervene when something goes wrong.
 | Waveform generation | File upload |
 | Moment export | Exporting a moment clip |
 | File hashing | Backfill action or new upload |
+| Image proxy variant pre-warm | Hourly maintenance loop (background) |
+
+### Named queues
+
+Jobs are split across three named queues so latency-sensitive work is never
+stuck behind a backlog. You can filter the dashboard by queue:
+
+| Queue | Priority | What it carries |
+|---|---|---|
+| `imageproxy` | Highest | Interactive, on-demand image transforms a user is waiting on |
+| `default` | Normal | Detection, transcription, transcode, waveforms, hashing, metadata, moment export |
+| `maintenance` | Lowest | Background upkeep — the hourly image-proxy variant pre-warm |
+
+### Periodic maintenance jobs
+
+Two background loops run on `worker`/`all` nodes without any user action:
+
+- **Metadata backfill** enqueues EXIF/media-metadata extraction for media files
+  that have never been extracted.
+- **Image-proxy variant pre-warm** (hourly) generates every cache variant for
+  each image so the first view is instant rather than waiting on a transform.
+  Disable it with `ALCOVES_IMAGE_PROXY_PREWARM_ENABLED=false`.
+
+Both give up on a file after **3 failed attempts**, so a permanently-broken
+file (e.g. a corrupted image) is never re-queued forever — it shows up as a
+failed job at most three times and is then dropped from the backfill scan.
 
 ### Reading the dashboard
 


### PR DESCRIPTION
## What

Adds a single source of truth for every image-proxy transform and an hourly background job that pre-generates them, plus proper logical queue separation. Implements all four asks:

1. **Hourly maintenance jobs that generate all image-proxy variants.** A new `imageproxy.StartPrewarmMaintenance` loop (worker/`all` nodes) scans live images not yet warmed at the current `VariantsVersion` and enqueues one `image:prewarm` task per file. Each task reads the source once and generates every missing variant into cache, idempotently skipping ones already cached. Mirrors the existing metadata-maintenance pattern.

2. **Single source of truth for the variants.** `backend/internal/services/imageproxy/variants.go` (`imageproxy.Variants`) is the canonical list of every `(size, format, quality)` the app uses, mirrored 1:1 by `frontend/shared/image-variants.ts`. Both the frontend (`AlcovesImage` gains a `variant` prop; `FilePreview` uses the shared builder) and the pre-warm job resolve from it, so a request's cache key is **exactly** the one the job generated. All 5 call sites (library cards, search, timeline, people, lightbox) are refactored off their scattered hardcoded sizes.

3. **Cap perpetually-failing jobs at 3 runs.** A corrupted/unsupported image that fails the libvips transform increments `files.image_proxy_attempts`; after **3 strikes** the scan drops the file, so a job that fails every time runs at most 3 times (never asynq's 25-retry default). Infrastructure failures (storage read/write blips) do **not** burn a strike. Migration `00022` adds the tracking columns + a partial index.

4. **Named queues per logical separation.** New `internal/queues` package is the single source of truth for queue names and weights: `imageproxy` (10) > `default` (3) > `maintenance` (1). The low-priority `maintenance` queue means a large pre-warm backfill can never starve interactive transforms.

Gated by `ALCOVES_IMAGE_PROXY_PREWARM_ENABLED` (default on). Architecture + admin docs and `.env.example` updated.

## Variant registry

| Variant | Box | Quality | Format | Sizing | Used by |
|---|---|---|---|---|---|
| `search` | 80×80 | 70 | jpeg | fixed | Search-result avatars |
| `timeline` | 240×240 | 70 | webp | fixed | Timeline grid |
| `face` | 300×300 | 80 | jpeg | fixed | People / face grid |
| `card` | 720×360 | 82 | jpeg | capped | Library browser cards |
| `preview` | 1920×1080 | 90 | jpeg | capped | Full-screen lightbox |

These values reproduce exactly what the UI already requested, so the refactor is behavior-preserving (proven by unit tests asserting identical proxy URLs).

## Testing

- **Backend:** full `go test ./...` green (no failures); `imageproxy` passes `-race`; `go vet` clean. New tests cover variant resolution/cache-key parity, the prewarm handler (generate-all, idempotent skip, 3-strike strike-out, transient-no-strike), the scan inclusion/exclusion rules, and queue routing.
- **Frontend:** `typecheck` clean; full unit suite (971 tests) green incl. new shared-registry + `AlcovesImage` variant tests; e2e flows for the changed pages **53 passed** (1 pre-existing unrelated home-redirect flake).