### PR TITLE
ci(release): publish version-tagged Docker images on release merges

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,89 @@
+name: Build Images
+
+# Reusable workflow: builds the backend + frontend Docker images and
+# (optionally) pushes them to GHCR. Called by:
+#   - publish.yml         → branch / PR / manual-tag builds
+#   - release-please.yml  → release builds (version_tags: true), so the
+#                           X.Y.Z / X.Y tags get published on every release
+#                           merge without depending on RELEASE_PLEASE_TOKEN.
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: "Push the built images to the registry"
+        type: boolean
+        default: true
+      version_tags:
+        description: "Also tag with X.Y.Z and X.Y read from the VERSION file"
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ${{ github.repository }}
+            context: .
+            file: ./Dockerfile
+          - image: ${{ github.repository }}-frontend
+            context: ./frontend
+            file: ./frontend/Dockerfile
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Read app version
+        id: appver
+        run: |
+          version="$(cat VERSION)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "major_minor=${version%.*}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to the Container registry
+        if: inputs.push
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ matrix.image }}
+          # The semver lines only fire when the ref is a tag (manual `v*`
+          # push). The raw lines fire when version_tags is requested — that's
+          # how release merges (which run on the `main` branch ref) still get
+          # X.Y.Z / X.Y tags pointing at the release commit.
+          tags: |
+            type=sha,prefix=,suffix=,format=short
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ steps.appver.outputs.version }},enable=${{ inputs.version_tags }}
+            type=raw,value=${{ steps.appver.outputs.major_minor }},enable=${{ inputs.version_tags }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ github.event.head_commit.timestamp || github.event.release.published_at }}
+            APP_VERSION=${{ steps.appver.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,62 +9,12 @@ on:
   release:
     types: [published]
 
-env:
-  REGISTRY: ghcr.io
-
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
+  build:
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image: ${{ github.repository }}
-            context: .
-            file: ./Dockerfile
-          - image: ${{ github.repository }}-frontend
-            context: ./frontend
-            file: ./frontend/Dockerfile
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Read app version
-        id: appver
-        run: echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
-
-      - name: Log in to the Container registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ matrix.image }}
-          tags: |
-            type=sha,prefix=,suffix=,format=short
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            COMMIT_SHA=${{ github.sha }}
-            BUILD_TIME=${{ github.event.head_commit.timestamp || github.event.release.published_at }}
-            APP_VERSION=${{ steps.appver.outputs.version }}
+    uses: ./.github/workflows/build-images.yml
+    with:
+      # Don't push on PRs — just verify the images build.
+      push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,11 +11,31 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - id: release
+        uses: googleapis/release-please-action@v5
         with:
           # Prefer a fine-grained PAT so the tag push from release-please
-          # triggers downstream workflows (publish.yml). Falls back to
-          # GITHUB_TOKEN — Release PRs still open, but the tag-driven
-          # Docker build won't fire until RELEASE_PLEASE_TOKEN is set.
+          # triggers downstream workflows. Falls back to GITHUB_TOKEN —
+          # Release PRs still open. Version-tagged Docker images no longer
+          # depend on this token: the publish-images job below builds them
+          # directly from this run when a release is created.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+  # When a Release PR merges, GitHub does not let release-please's
+  # GITHUB_TOKEN-created tag/release re-trigger publish.yml, so the version
+  # tags would never be published. Instead we build + push them here, from
+  # the merge commit that release-please just tagged (its VERSION file already
+  # holds the new version), guaranteeing ghcr images tagged X.Y.Z and X.Y.
+  publish-images:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-images.yml
+    with:
+      push: true
+      version_tags: true


### PR DESCRIPTION
## Problem

When a Release PR merges to `main`, the version-tagged Docker images (`0.x.y`, `0.x`) are **never published** — only the `main` + short-sha tags from the branch-push build.

Root cause: release-please pushes the `v0.x.y` tag using `GITHUB_TOKEN`, and GitHub deliberately **suppresses workflow triggers from `GITHUB_TOKEN`-created tags/releases** (anti-recursion). So `publish.yml`'s `tags: v*` and `release: published` triggers never fire for releases. The `RELEASE_PLEASE_TOKEN` PAT that would have side-stepped this is not configured (repo secrets only have `SSH_HOST`).

Evidence: no `v0.x.y`-triggered run exists in the publish-workflow history — every release merge (`0.20.0`, `0.21.0`, …) only produced a branch-`push` build.

## Fix

Publish the version tags from *within* the release-please run, which **is** triggered by the real merge push (so it always executes) — no PAT required.

- **New `build-images.yml`** — reusable workflow (`workflow_call`) holding the existing backend + frontend matrix build, with `push` and `version_tags` inputs. Single source of truth, so the two callers can't drift.
- **`publish.yml`** — now a thin caller for branch / PR / manual-`v*`-tag / manual-release builds. Behavior unchanged (`push=false` on PRs; `type=semver` still tags manual tag/release refs).
- **`release-please.yml`** — exposes `release_created` and adds a `publish-images` job gated on it that calls the reusable workflow with `version_tags: true`. It builds the merge commit release-please just tagged — whose `VERSION` already holds the new version — and pushes `X.Y.Z` + `X.Y`.

## Trigger-path matrix (no regressions)

| Event | Result |
|---|---|
| PR opened | build-verify only, no push *(unchanged)* |
| Feature merge → main | `main` + sha tags; `publish-images` skipped *(unchanged)* |
| **Release merge → main** | `main` + sha **and** `0.x.y` + `0.x` ← **the fix** |
| Manual `v*` tag push | `0.x.y` + `0.x` via `type=semver` *(preserved)* |
| Manually-published GitHub release | version tags via `type=semver` *(preserved)* |

## Validation

- `actionlint` clean on all three workflows (validates reusable-workflow calls, input types, expressions, permissions).
- YAML parses.

## Notes

- `latest` is intentionally **not** added — only the version tags were requested. Easy to add a `type=raw,value=latest` line later if desired.
- Setting `RELEASE_PLEASE_TOKEN` is now optional; the version tags no longer depend on it.