### PR TITLE
feat(queue): dedicated per-job-type queues ranked by importance and complexity

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -218,10 +218,13 @@ func main() {
 	if cfg.Mode == "all" || cfg.Mode == "worker" {
 		asynqServer = asynq.NewServer(asynqRedisOpt, asynq.Config{
 			Concurrency: 8,
-			// Queue weights come from the single source of truth in the queues
-			// package: imageproxy (interactive) ≫ default (batch ML/video) ≫
-			// maintenance (background cache pre-warm), so latency-sensitive work
-			// is never starved by a large maintenance backfill.
+			// Per-job-type queue weights come from the single source of truth in
+			// the queues package, ranked by importance ÷ complexity: interactive
+			// image transforms ≫ fast post-upload derivations (metadata,
+			// thumbnails, hashes) ≫ moderate media ≫ ML inference ≫ heavy
+			// long-runners (video transcode, whisper transcription) ≫ background
+			// maintenance. Latency-sensitive work is never starved by a large
+			// batch of slow jobs.
 			Queues: queues.Priorities,
 		})
 

--- a/backend/internal/queuerouting/routing_test.go
+++ b/backend/internal/queuerouting/routing_test.go
@@ -1,0 +1,139 @@
+// Package queuerouting holds an integration test that pins which Asynq queue
+// every enqueue helper routes to. It lives in its own package so it can import
+// every service without creating an import cycle through the queues package.
+//
+// The test guards a subtle, easy-to-regress contract: a service that forgets
+// the asynq.Queue(...) option silently falls back to the "default" queue, which
+// would quietly undo the per-job-type prioritisation. Each case below enqueues
+// one real task and asserts it landed on the intended queue.
+//
+// It uses an in-memory miniredis instance per subtest, so it needs no external
+// Redis and can't be polluted by uniqueness locks left over from prior runs.
+package queuerouting
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/hibiken/asynq"
+
+	"github.com/alcoves/alcoves-backend/internal/queues"
+	"github.com/alcoves/alcoves-backend/internal/services/audiodetection"
+	"github.com/alcoves/alcoves-backend/internal/services/facedetection"
+	"github.com/alcoves/alcoves-backend/internal/services/filehash"
+	"github.com/alcoves/alcoves-backend/internal/services/metadata"
+	"github.com/alcoves/alcoves-backend/internal/services/momentexport"
+	"github.com/alcoves/alcoves-backend/internal/services/objectdetection"
+	"github.com/alcoves/alcoves-backend/internal/services/transcribe"
+	"github.com/alcoves/alcoves-backend/internal/services/videoproxy"
+	"github.com/alcoves/alcoves-backend/internal/services/waveform"
+)
+
+func TestEnqueueHelpersRouteToIntendedQueue(t *testing.T) {
+	cases := []struct {
+		name  string
+		queue string
+		// enqueue performs exactly one enqueue using the service's real helper,
+		// against the provided client.
+		enqueue func(c *asynq.Client) error
+	}{
+		{
+			name:  "transcribe",
+			queue: queues.Transcription,
+			enqueue: func(c *asynq.Client) error {
+				return transcribe.NewService(nil, nil, c, nil, nil, nil).EnqueueTranscribe("lib", "file")
+			},
+		},
+		{
+			name:  "video-proxy",
+			queue: queues.VideoTranscode,
+			enqueue: func(c *asynq.Client) error {
+				return videoproxy.NewService(nil, nil, c, nil).EnqueueVideoProxy("lib", "file", false)
+			},
+		},
+		{
+			name:  "video-thumbnail",
+			queue: queues.Thumbnail,
+			enqueue: func(c *asynq.Client) error {
+				return videoproxy.NewService(nil, nil, c, nil).EnqueueVideoThumbnail("lib", "file")
+			},
+		},
+		{
+			name:  "moment-export",
+			queue: queues.MomentExport,
+			enqueue: func(c *asynq.Client) error {
+				return momentexport.NewService(nil, nil, c).Enqueue("lib", "file", "moment")
+			},
+		},
+		{
+			name:  "face-detect",
+			queue: queues.FaceDetection,
+			enqueue: func(c *asynq.Client) error {
+				return facedetection.NewService(nil, nil, c, nil).EnqueueFaceDetection("lib", "file")
+			},
+		},
+		{
+			name:  "object-detect",
+			queue: queues.ObjectDetection,
+			enqueue: func(c *asynq.Client) error {
+				return objectdetection.NewService(nil, nil, c, nil).EnqueueObjectDetection("lib", "file")
+			},
+		},
+		{
+			name:  "metadata",
+			queue: queues.Metadata,
+			enqueue: func(c *asynq.Client) error {
+				return metadata.NewService(nil, nil, c, nil).EnqueueMetadata("lib", "file")
+			},
+		},
+		{
+			name:  "waveform",
+			queue: queues.Waveform,
+			enqueue: func(c *asynq.Client) error {
+				return waveform.NewService(nil, nil, c, nil, nil).EnqueueWaveform("lib", "file")
+			},
+		},
+		{
+			name:  "audio-detect",
+			queue: queues.AudioDetection,
+			enqueue: func(c *asynq.Client) error {
+				return audiodetection.NewService(nil, nil, c, nil, nil).EnqueueDetect("lib", "file")
+			},
+		},
+		{
+			name:    "file-hash",
+			queue:   queues.Hash,
+			enqueue: func(c *asynq.Client) error { return filehash.NewService(nil, nil, c).EnqueueFileHash("lib", "file") },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := miniredis.RunT(t)
+			opt := asynq.RedisClientOpt{Addr: mr.Addr()}
+
+			client := asynq.NewClient(opt)
+			defer client.Close()
+			insp := asynq.NewInspector(opt)
+			defer insp.Close()
+
+			if err := tc.enqueue(client); err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+
+			info, err := insp.GetQueueInfo(tc.queue)
+			if err != nil {
+				t.Fatalf("GetQueueInfo(%q): %v — task did not land on the intended queue", tc.queue, err)
+			}
+			if info.Pending < 1 {
+				t.Fatalf("expected >=1 pending task on queue %q, got %d", tc.queue, info.Pending)
+			}
+
+			// Nothing should have leaked onto the default fallback queue. A
+			// missing asynq.Queue option would send the task there instead.
+			if def, err := insp.GetQueueInfo(queues.Default); err == nil && def.Pending != 0 {
+				t.Fatalf("task leaked onto the default queue (%d pending); the asynq.Queue option is missing", def.Pending)
+			}
+		})
+	}
+}

--- a/backend/internal/queues/queues.go
+++ b/backend/internal/queues/queues.go
@@ -1,40 +1,118 @@
 // Package queues is the single source of truth for the named Asynq queues used
 // across Alcoves. Each logical class of background work routes to its own queue
 // so that latency-sensitive work (interactive image transforms) is never stuck
-// behind heavy batch work (ML inference, video transcode) or low-priority
-// maintenance (cache pre-warming).
+// behind heavy batch work (whisper transcription, video transcode) or
+// low-priority maintenance (cache pre-warming).
+//
+// Ranking philosophy — weight ≈ importance ÷ complexity:
+//
+//   - importance: how much a user is actively blocked on the result. An
+//     on-demand thumbnail (someone is staring at a spinner) outranks a
+//     background ML enrichment that nobody asked for yet.
+//   - complexity: how long/heavy the job is. A multi-minute whisper transcribe
+//     or full video transcode must not hog the worker pool ahead of the dozens
+//     of sub-second jobs queued behind it, so heavier work is demoted.
+//
+// The result is a clear ladder: interactive transforms first, then cheap
+// post-upload derivations (metadata, thumbnails, hashes), then moderate media
+// work, then CPU-bound ML inference, and finally the genuinely heavy
+// long-runners (video transcode, whisper) just above pure background upkeep.
 //
 // To add a queue: add a constant here, give it a weight in Priorities, and
 // register its handler(s) in cmd/server/main.go. The worker's asynq.Config
-// reads Priorities directly so a new queue is picked up in one place.
+// reads Priorities directly so a new queue is picked up in one place. The admin
+// jobs dashboard discovers queues at runtime via the Asynq inspector, so a new
+// queue needs no dashboard changes.
 package queues
 
 // Named queues. The string values are the on-the-wire queue names stored in
 // Redis; do not rename them without a migration plan for in-flight tasks.
 const (
-	// Default carries general async work: hashing, metadata/EXIF, waveforms,
-	// face/object detection, audio detection, transcription, video transcode,
-	// and moment export.
-	Default = "default"
-
 	// ImageProxy carries interactive, on-demand image transforms. A user is
 	// usually blocked on these (a thumbnail is rendering), so it gets the
-	// highest weight.
+	// highest weight by a wide margin.
 	ImageProxy = "imageproxy"
 
-	// Maintenance carries low-priority background upkeep that no user is
-	// waiting on — currently the hourly image-proxy variant pre-warm. Lowest
-	// weight so a large backfill batch can never starve interactive transforms
-	// or the default queue.
+	// Metadata carries EXIF/GPS + ffprobe extraction. Cheap and fast, and it
+	// unblocks core display surfaces (Timeline, Map, file details), so it sits
+	// near the top.
+	Metadata = "metadata"
+
+	// Thumbnail carries video poster-frame extraction — a fast ffmpeg seek that
+	// makes the library grid usable. The owner explicitly wants thumbnailing to
+	// outrank the heavy long-runners below.
+	Thumbnail = "thumbnail"
+
+	// Hash carries SHA256 content hashing for dedup. Fast and important for
+	// correctness, but no user is blocked on it, so it ranks just below the
+	// display-critical derivations.
+	Hash = "hash"
+
+	// Default is retained ONLY as a drain target for tasks enqueued by an older
+	// binary before this rollout, and as a fallback for any future enqueue that
+	// forgets to name a queue. No current code routes new work here. Kept at a
+	// middle weight so any transient backlog drains promptly without starving
+	// interactive work.
+	Default = "default"
+
+	// MomentExport carries short user-initiated clip encodes. Someone clicked
+	// "export" and is waiting, so it outranks background ML, but it's a real
+	// ffmpeg encode so it sits below the cheap derivations.
+	MomentExport = "moment-export"
+
+	// Waveform carries audio waveform peak generation — a moderate ffmpeg PCM
+	// pass feeding the editor/player UI.
+	Waveform = "waveform"
+
+	// ObjectDetection carries YOLO ONNX inference. CPU-bound background
+	// enrichment for search; nobody is blocked on it in real time.
+	ObjectDetection = "object-detection"
+
+	// FaceDetection carries face ONNX inference + clustering. Same complexity
+	// class as object detection; background enrichment.
+	FaceDetection = "face-detection"
+
+	// AudioDetection carries AudioSet ONNX inference. Runs over decoded audio
+	// from (often long) video, so it's a touch heavier than the image-based
+	// detectors and ranks just below them.
+	AudioDetection = "audio-detection"
+
+	// VideoTranscode carries full video proxy transcodes — heavy, multi-minute
+	// ffmpeg work. Demoted near the bottom so a big import can't starve the
+	// fast jobs queued behind it.
+	VideoTranscode = "video-transcode"
+
+	// Transcription carries whisper.cpp speech-to-text. The single heaviest,
+	// longest-running job class (minutes for long media), so it sits at the
+	// very bottom of the real-work ladder — above only pure maintenance.
+	Transcription = "transcription"
+
+	// Maintenance carries low-priority background upkeep that no user is waiting
+	// on — currently the hourly image-proxy variant pre-warm. Lowest weight so a
+	// large backfill batch can never starve anything above it.
 	Maintenance = "maintenance"
 )
 
 // Priorities is the asynq queue-weight map consumed by the worker in
 // cmd/server/main.go. Higher weight = a larger share of worker attention.
-// ImageProxy ≫ Default ≫ Maintenance encodes "users first, batch second,
-// upkeep last".
+// Asynq samples non-strictly across NON-EMPTY queues in proportion to these
+// weights, so a low-weight queue is never starved when it's the only one with
+// work — it simply yields to higher-priority queues while they have a backlog.
+//
+// The ladder (high → low): interactive transforms ≫ fast derivations ≫
+// moderate media ≫ ML inference ≫ heavy long-runners ≫ maintenance.
 var Priorities = map[string]int{
-	ImageProxy:  10,
-	Default:     3,
-	Maintenance: 1,
+	ImageProxy:      100,
+	Metadata:        70,
+	Thumbnail:       65,
+	Hash:            60,
+	Default:         50,
+	MomentExport:    45,
+	Waveform:        40,
+	ObjectDetection: 30,
+	FaceDetection:   30,
+	AudioDetection:  25,
+	VideoTranscode:  10,
+	Transcription:   5,
+	Maintenance:     1,
 }

--- a/backend/internal/queues/queues_test.go
+++ b/backend/internal/queues/queues_test.go
@@ -1,0 +1,123 @@
+package queues
+
+import "testing"
+
+// allQueues is every named queue this package defines. Keeping it explicit (vs
+// ranging over Priorities) lets the tests assert the map and the constant set
+// stay in lockstep — a new constant without a weight, or a stray weight without
+// a constant, both fail.
+var allQueues = []string{
+	ImageProxy,
+	Metadata,
+	Thumbnail,
+	Hash,
+	Default,
+	MomentExport,
+	Waveform,
+	ObjectDetection,
+	FaceDetection,
+	AudioDetection,
+	VideoTranscode,
+	Transcription,
+	Maintenance,
+}
+
+// TestEveryQueueHasAWeight guards against adding a queue constant but forgetting
+// to give it a weight in Priorities — an unweighted queue would not be polled by
+// the worker at all, silently stranding its tasks.
+func TestEveryQueueHasAWeight(t *testing.T) {
+	for _, q := range allQueues {
+		if _, ok := Priorities[q]; !ok {
+			t.Errorf("queue %q has no weight in Priorities", q)
+		}
+	}
+	if len(Priorities) != len(allQueues) {
+		t.Errorf("Priorities has %d entries but %d queues are defined; a weight exists without a matching constant", len(Priorities), len(allQueues))
+	}
+}
+
+// TestNoDuplicateQueueNames ensures two constants never resolve to the same
+// on-the-wire name, which would silently merge two job classes into one queue.
+func TestNoDuplicateQueueNames(t *testing.T) {
+	seen := map[string]bool{}
+	for _, q := range allQueues {
+		if seen[q] {
+			t.Errorf("duplicate queue name %q", q)
+		}
+		seen[q] = true
+	}
+}
+
+// TestWeightsArePositive — asynq treats a non-positive weight as "never poll",
+// so every real queue must be >= 1.
+func TestWeightsArePositive(t *testing.T) {
+	for q, w := range Priorities {
+		if w < 1 {
+			t.Errorf("queue %q has non-positive weight %d", q, w)
+		}
+	}
+}
+
+// TestRankingLadder pins the documented priority ordering. These are the
+// product invariants — if a future change reweights a queue in a way that
+// violates the ladder (e.g. makes whisper outrank thumbnailing), this fails.
+func TestRankingLadder(t *testing.T) {
+	// The full high → low ladder. Each entry must be strictly heavier than the
+	// next, except the ML-detection trio which is allowed to tie.
+	ladder := []struct {
+		name      string
+		queue     string
+		mayTieNxt bool
+	}{
+		{"imageproxy", ImageProxy, false},
+		{"metadata", Metadata, false},
+		{"thumbnail", Thumbnail, false},
+		{"hash", Hash, false},
+		{"default", Default, false},
+		{"moment-export", MomentExport, false},
+		{"waveform", Waveform, false},
+		{"object-detection", ObjectDetection, true}, // may tie face-detection
+		{"face-detection", FaceDetection, false},
+		{"audio-detection", AudioDetection, false},
+		{"video-transcode", VideoTranscode, false},
+		{"transcription", Transcription, false},
+		{"maintenance", Maintenance, false},
+	}
+
+	for i := 0; i+1 < len(ladder); i++ {
+		hi, lo := ladder[i], ladder[i+1]
+		wHi, wLo := Priorities[hi.queue], Priorities[lo.queue]
+		if hi.mayTieNxt {
+			if wHi < wLo {
+				t.Errorf("%s (%d) must be >= %s (%d)", hi.name, wHi, lo.name, wLo)
+			}
+		} else if wHi <= wLo {
+			t.Errorf("%s (%d) must outrank %s (%d)", hi.name, wHi, lo.name, wLo)
+		}
+	}
+}
+
+// TestUserMandatedConstraints encodes the explicit asks from the feature
+// request: whisper transcription and heavy video transcode are demoted below
+// fast thumbnailing, and whisper — the longest-running class — sits at or below
+// video transcode.
+func TestUserMandatedConstraints(t *testing.T) {
+	if Priorities[Transcription] >= Priorities[Thumbnail] {
+		t.Errorf("transcription (%d) must be lower priority than thumbnail (%d)", Priorities[Transcription], Priorities[Thumbnail])
+	}
+	if Priorities[VideoTranscode] >= Priorities[Thumbnail] {
+		t.Errorf("video-transcode (%d) must be lower priority than thumbnail (%d)", Priorities[VideoTranscode], Priorities[Thumbnail])
+	}
+	if Priorities[Transcription] > Priorities[VideoTranscode] {
+		t.Errorf("whisper transcription (%d) is the heaviest job class and must not outrank video-transcode (%d)", Priorities[Transcription], Priorities[VideoTranscode])
+	}
+	// Interactive transforms always win; pure maintenance always loses.
+	for _, q := range allQueues {
+		if q != ImageProxy && Priorities[ImageProxy] <= Priorities[q] {
+			t.Errorf("imageproxy must be the highest-priority queue, but %q (%d) >= imageproxy (%d)", q, Priorities[q], Priorities[ImageProxy])
+		}
+		if q != Maintenance && Priorities[Maintenance] >= Priorities[q] {
+			t.Errorf("maintenance must be the lowest-priority queue, but %q (%d) <= maintenance (%d)", q, Priorities[q], Priorities[Maintenance])
+		}
+	}
+}

--- a/backend/internal/services/audiodetection/service.go
+++ b/backend/internal/services/audiodetection/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/alcoves/alcoves-backend/internal/config"
 	"github.com/alcoves/alcoves-backend/internal/models"
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/settings"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
 )
@@ -56,7 +57,10 @@ func (s *Service) EnqueueDetect(libraryID, fileID string) error {
 	if err != nil {
 		return fmt.Errorf("create audio-detect task: %w", err)
 	}
+	// AudioSet ONNX inference over decoded (often long) audio — background
+	// enrichment, ranked just below the image-based detectors.
 	_, err = s.asynqClient.Enqueue(task,
+		asynq.Queue(queues.AudioDetection),
 		asynq.Retention(completedTaskRetention),
 		asynq.Unique(enqueueUniqueWindow),
 	)

--- a/backend/internal/services/audiodetection/worker_test.go
+++ b/backend/internal/services/audiodetection/worker_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/hibiken/asynq"
+
+	"github.com/alcoves/alcoves-backend/internal/queues"
 )
 
 func TestNewTask_TypeAndPayload(t *testing.T) {
@@ -77,9 +79,11 @@ func TestEnqueueDetect_DedupsConcurrentRequests(t *testing.T) {
 
 	// Sanity: bare client without dedup option would surface
 	// ErrDuplicateTask. Confirm the underlying option is what gates this,
-	// not some other code path that silently accepts everything.
+	// not some other code path that silently accepts everything. The raw
+	// enqueue must target the same queue the service uses, since asynq keys
+	// its uniqueness lock by queue + type + payload.
 	task, _ := newTask(Payload{LibraryID: "lib-1", FileID: "file-1"})
-	_, err := client.Enqueue(task, asynq.Unique(enqueueUniqueWindow))
+	_, err := client.Enqueue(task, asynq.Queue(queues.AudioDetection), asynq.Unique(enqueueUniqueWindow))
 	if !errors.Is(err, asynq.ErrDuplicateTask) {
 		t.Fatalf("expected asynq.ErrDuplicateTask from raw client, got: %v", err)
 	}

--- a/backend/internal/services/facedetection/bulk.go
+++ b/backend/internal/services/facedetection/bulk.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/alcoves/alcoves-backend/internal/models"
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
 )
 
@@ -40,7 +41,7 @@ func EnqueueExistingLibraryImages(client *asynq.Client, db *gorm.DB, libraryID s
 			log.Printf("failed to create task for file %s: %v", f.ID, err)
 			continue
 		}
-		if _, err := client.Enqueue(task, asynq.Retention(completedTaskRetention)); err != nil {
+		if _, err := client.Enqueue(task, asynq.Queue(queues.FaceDetection), asynq.Retention(completedTaskRetention)); err != nil {
 			log.Printf("failed to enqueue task for file %s: %v", f.ID, err)
 			continue
 		}

--- a/backend/internal/services/facedetection/service.go
+++ b/backend/internal/services/facedetection/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hibiken/asynq"
 	"gorm.io/gorm"
 
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
 )
 
@@ -38,7 +39,8 @@ func (s *Service) EnqueueFaceDetection(libraryID, fileID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create face detect task: %w", err)
 	}
-	_, err = s.asynqClient.Enqueue(task, asynq.Retention(completedTaskRetention))
+	// Face ONNX inference + clustering: CPU-bound background enrichment.
+	_, err = s.asynqClient.Enqueue(task, asynq.Queue(queues.FaceDetection), asynq.Retention(completedTaskRetention))
 	if err != nil {
 		return fmt.Errorf("failed to enqueue face detect task: %w", err)
 	}

--- a/backend/internal/services/filehash/bulk.go
+++ b/backend/internal/services/filehash/bulk.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/hibiken/asynq"
 	"gorm.io/gorm"
+
+	"github.com/alcoves/alcoves-backend/internal/queues"
 )
 
 // EnqueueUnhashedFiles queries for all files without a hash and enqueues
@@ -33,7 +35,7 @@ func EnqueueUnhashedFiles(client *asynq.Client, db *gorm.DB) (int, error) {
 			log.Printf("failed to create hash task for file %s: %v", f.ID, err)
 			continue
 		}
-		if _, err := client.Enqueue(task, asynq.Retention(completedTaskRetention)); err != nil {
+		if _, err := client.Enqueue(task, asynq.Queue(queues.Hash), asynq.Retention(completedTaskRetention)); err != nil {
 			log.Printf("failed to enqueue hash task for file %s: %v", f.ID, err)
 			continue
 		}

--- a/backend/internal/services/filehash/service.go
+++ b/backend/internal/services/filehash/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hibiken/asynq"
 	"gorm.io/gorm"
 
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
 )
 
@@ -35,7 +36,8 @@ func (s *Service) EnqueueFileHash(libraryID, fileID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create file hash task: %w", err)
 	}
-	_, err = s.asynqClient.Enqueue(task, asynq.Retention(completedTaskRetention))
+	// SHA256 content hashing for dedup: fast, no user blocked on it.
+	_, err = s.asynqClient.Enqueue(task, asynq.Queue(queues.Hash), asynq.Retention(completedTaskRetention))
 	if err != nil {
 		return fmt.Errorf("failed to enqueue file hash task: %w", err)
 	}

--- a/backend/internal/services/filehash/service_bulk_test.go
+++ b/backend/internal/services/filehash/service_bulk_test.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/alcoves/alcoves-backend/internal/models"
+	"github.com/alcoves/alcoves-backend/internal/queues"
 )
 
 // testRedisOpt isolates these tests on a dedicated Redis logical DB so parallel
@@ -59,10 +60,10 @@ func TestEnqueueFileHash(t *testing.T) {
 		t.Fatalf("EnqueueFileHash: %v", err)
 	}
 
-	// Confirm the task landed in the default queue.
+	// Confirm the task landed in the dedicated hash queue.
 	insp := asynq.NewInspector(testRedisOpt())
 	defer insp.Close()
-	info, err := insp.GetQueueInfo("default")
+	info, err := insp.GetQueueInfo(queues.Hash)
 	if err != nil {
 		t.Fatalf("GetQueueInfo: %v", err)
 	}

--- a/backend/internal/services/metadata/service.go
+++ b/backend/internal/services/metadata/service.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/alcoves/alcoves-backend/internal/config"
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
 )
 
@@ -16,7 +17,8 @@ import (
 const TaskTypeMetadata = "file:metadata"
 
 // Service owns enqueuing metadata-extraction work. It mirrors the waveform
-// service: version-tracked, idempotent, runs on the shared default queue.
+// service: version-tracked, idempotent, runs on the high-priority metadata
+// queue (see internal/queues).
 type Service struct {
 	db          *gorm.DB
 	storage     *storage.Service
@@ -36,7 +38,9 @@ func (s *Service) EnqueueMetadata(libraryID, fileID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create metadata task: %w", err)
 	}
-	if _, err := s.asynqClient.Enqueue(task, asynq.Retention(completedTaskRetention)); err != nil {
+	// EXIF/ffprobe extraction is fast and unblocks core display surfaces
+	// (Timeline, Map, file details), so it runs on a high-priority queue.
+	if _, err := s.asynqClient.Enqueue(task, asynq.Queue(queues.Metadata), asynq.Retention(completedTaskRetention)); err != nil {
 		return fmt.Errorf("failed to enqueue metadata task: %w", err)
 	}
 	log.Printf("Enqueued metadata extraction for file %s in library %s", fileID, libraryID)

--- a/backend/internal/services/momentexport/service.go
+++ b/backend/internal/services/momentexport/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hibiken/asynq"
 	"gorm.io/gorm"
 
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
 )
 
@@ -44,7 +45,10 @@ func (s *Service) Enqueue(libraryID, fileID, momentID string) error {
 		return fmt.Errorf("failed to marshal moment export payload: %w", err)
 	}
 	task := asynq.NewTask(TaskTypeMomentExport, payload)
-	if _, err := s.asynqClient.Enqueue(task, asynq.Retention(completedTaskRetention)); err != nil {
+	// User-initiated clip encode: someone clicked "export" and is waiting, so it
+	// outranks background ML, but it's a real ffmpeg encode so it sits below the
+	// cheap post-upload derivations.
+	if _, err := s.asynqClient.Enqueue(task, asynq.Queue(queues.MomentExport), asynq.Retention(completedTaskRetention)); err != nil {
 		return fmt.Errorf("failed to enqueue moment export: %w", err)
 	}
 	log.Printf("Enqueued moment export moment=%s file=%s library=%s", momentID, fileID, libraryID)

--- a/backend/internal/services/objectdetection/bulk.go
+++ b/backend/internal/services/objectdetection/bulk.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/alcoves/alcoves-backend/internal/models"
+	"github.com/alcoves/alcoves-backend/internal/queues"
 )
 
 // EnqueueExistingLibraryImages enqueues object:detect tasks for all image files
@@ -39,7 +40,7 @@ func EnqueueExistingLibraryImages(client *asynq.Client, db *gorm.DB, libraryID s
 			log.Printf("failed to create object detect task for file %s: %v", f.ID, err)
 			continue
 		}
-		if _, err := client.Enqueue(task); err != nil {
+		if _, err := client.Enqueue(task, asynq.Queue(queues.ObjectDetection)); err != nil {
 			log.Printf("failed to enqueue object detect task for file %s: %v", f.ID, err)
 			continue
 		}

--- a/backend/internal/services/objectdetection/service.go
+++ b/backend/internal/services/objectdetection/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hibiken/asynq"
 	"gorm.io/gorm"
 
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
 )
 
@@ -35,7 +36,8 @@ func (s *Service) EnqueueObjectDetection(libraryID, fileID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create object detect task: %w", err)
 	}
-	_, err = s.asynqClient.Enqueue(task)
+	// YOLO ONNX inference: CPU-bound background enrichment for search.
+	_, err = s.asynqClient.Enqueue(task, asynq.Queue(queues.ObjectDetection))
 	if err != nil {
 		return fmt.Errorf("failed to enqueue object detect task: %w", err)
 	}

--- a/backend/internal/services/transcribe/service.go
+++ b/backend/internal/services/transcribe/service.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/alcoves/alcoves-backend/internal/config"
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/activity"
 	"github.com/alcoves/alcoves-backend/internal/services/settings"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
@@ -45,7 +46,10 @@ func (s *Service) EnqueueTranscribe(libraryID, fileID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create transcribe task: %w", err)
 	}
-	if _, err := s.asynqClient.Enqueue(task, asynq.Retention(completedTaskRetention)); err != nil {
+	// Whisper transcription is the heaviest, longest-running job class, so it
+	// runs on its own lowest-real-work queue (above only maintenance) and never
+	// hogs the worker pool ahead of fast jobs like thumbnailing.
+	if _, err := s.asynqClient.Enqueue(task, asynq.Queue(queues.Transcription), asynq.Retention(completedTaskRetention)); err != nil {
 		return fmt.Errorf("failed to enqueue transcribe task: %w", err)
 	}
 	log.Printf("Enqueued transcribe for file %s in library %s", fileID, libraryID)

--- a/backend/internal/services/videoproxy/service.go
+++ b/backend/internal/services/videoproxy/service.go
@@ -10,6 +10,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/alcoves/alcoves-backend/internal/models"
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/activity"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
 )
@@ -40,7 +41,10 @@ func (s *Service) EnqueueVideoProxy(libraryID, fileID string, force bool) error 
 	if err != nil {
 		return fmt.Errorf("failed to create video proxy task: %w", err)
 	}
-	_, err = s.asynqClient.Enqueue(task, asynq.Retention(completedTaskRetention))
+	// A full proxy transcode is heavy, multi-minute ffmpeg work, so it runs on
+	// the low-priority video-transcode queue and never starves the fast jobs
+	// (thumbnails, metadata) queued behind it.
+	_, err = s.asynqClient.Enqueue(task, asynq.Queue(queues.VideoTranscode), asynq.Retention(completedTaskRetention))
 	if err != nil {
 		return fmt.Errorf("failed to enqueue video proxy task: %w", err)
 	}
@@ -53,7 +57,10 @@ func (s *Service) EnqueueVideoThumbnail(libraryID, fileID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create video thumbnail task: %w", err)
 	}
-	_, err = s.asynqClient.Enqueue(task, asynq.Retention(completedTaskRetention))
+	// Thumbnail extraction is a fast ffmpeg seek that makes the grid usable, so
+	// it runs on its own high-priority queue — explicitly ranked above heavy
+	// video transcode and whisper transcription.
+	_, err = s.asynqClient.Enqueue(task, asynq.Queue(queues.Thumbnail), asynq.Retention(completedTaskRetention))
 	if err != nil {
 		return fmt.Errorf("failed to enqueue video thumbnail task: %w", err)
 	}

--- a/backend/internal/services/waveform/service.go
+++ b/backend/internal/services/waveform/service.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/alcoves/alcoves-backend/internal/config"
+	"github.com/alcoves/alcoves-backend/internal/queues"
 	"github.com/alcoves/alcoves-backend/internal/services/activity"
 	"github.com/alcoves/alcoves-backend/internal/services/storage"
 )
@@ -34,7 +35,8 @@ func (s *Service) EnqueueWaveform(libraryID, fileID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create waveform task: %w", err)
 	}
-	if _, err := s.asynqClient.Enqueue(task, asynq.Retention(completedTaskRetention)); err != nil {
+	// A moderate ffmpeg PCM pass feeding the editor/player UI.
+	if _, err := s.asynqClient.Enqueue(task, asynq.Queue(queues.Waveform), asynq.Retention(completedTaskRetention)); err != nil {
 		return fmt.Errorf("failed to enqueue waveform task: %w", err)
 	}
 	log.Printf("Enqueued waveform for file %s in library %s", fileID, libraryID)

--- a/website/src/content/docs/architecture/backend-architecture-go.md
+++ b/website/src/content/docs/architecture/backend-architecture-go.md
@@ -74,9 +74,11 @@ A contributor adding a new service or route edits this file.
    `EnsureModels` for face and object detection. Non-fatal: logs a warning on
    failure and the first job will block while the model downloads lazily.
 
-6. **Start the Asynq worker** (`mode=all|worker`) — concurrency 8, with queue
-   priorities that let interactive image-transform requests preempt batch ML
-   work.
+6. **Start the Asynq worker** (`mode=all|worker`) — concurrency 8, with
+   per-job-type queue priorities (weighted by importance ÷ complexity) that let
+   interactive image-transform requests preempt batch ML work and keep the
+   heavy long-runners (video transcode, whisper transcription) from starving
+   fast jobs like thumbnailing.
 
 7. **Configure Echo** — install the custom validator, then the global middleware
    chain: logger, recover, CORS (strict allowlist, never a wildcard), auth
@@ -289,22 +291,29 @@ files) and `export` (on moments).
 
 ### Queue tasks
 
-| Task | What it does |
-|---|---|
-| `image:proxy` | On-demand image transforms (resize, crop, format) |
-| `face:detect` | Face detection and embedding for a file |
-| `object:detect` | COCO object detection for a file |
-| `video:proxy` | Video transcoding to HLS/MP4 |
-| `video:thumbnail` | Extracts a thumbnail from a video file |
-| `file:hash` | SHA-256 dedup hash |
-| `moment:export` | Exports a named moment clip to MP4 |
-| `file:transcribe` | whisper.cpp speech transcription |
-| `file:audio-detect` | AudioSet audio-event classification |
-| `file:waveform` | Extracts and stores the audio waveform |
+| Task | Queue | What it does |
+|---|---|---|
+| `image:proxy` | `imageproxy` | On-demand image transforms (resize, crop, format) |
+| `file:metadata` | `metadata` | EXIF/GPS + ffprobe metadata extraction |
+| `video:thumbnail` | `thumbnail` | Extracts a thumbnail from a video file |
+| `file:hash` | `hash` | SHA-256 dedup hash |
+| `moment:export` | `moment-export` | Exports a named moment clip to MP4 |
+| `file:waveform` | `waveform` | Extracts and stores the audio waveform |
+| `object:detect` | `object-detection` | COCO object detection for a file |
+| `face:detect` | `face-detection` | Face detection and embedding for a file |
+| `file:audio-detect` | `audio-detection` | AudioSet audio-event classification |
+| `video:proxy` | `video-transcode` | Video transcoding to HLS/MP4 |
+| `file:transcribe` | `transcription` | whisper.cpp speech transcription |
+| `image:prewarm` | `maintenance` | Hourly pre-warm of every image-proxy variant |
 
-The queue runs at concurrency 8 with image proxy jobs prioritized above batch
-ML work, so interactive thumbnail requests are not queued behind a long
-transcription job.
+The queue runs at concurrency 8. Each job type has its own queue, weighted by
+**importance ÷ complexity** (see `internal/queues`): interactive image
+transforms rank highest, fast post-upload derivations (metadata, thumbnails,
+hashes) next, then ML inference, then the heavy long-runners (full video
+transcode, whisper transcription) just above background maintenance. So a long
+transcription or transcode job can never queue ahead of an interactive
+thumbnail request — and, per the explicit priority intent, whisper sits *below*
+thumbnailing.
 
 ### Idempotency and re-triggering
 

--- a/website/src/content/docs/architecture/media-processing-pipeline.md
+++ b/website/src/content/docs/architecture/media-processing-pipeline.md
@@ -24,15 +24,25 @@ This page covers the non-ML media pipeline. AI-driven analysis (face recognition
 - **Asynq job queue** (backed by Dragonfly/Redis) — async task dispatch, deduplication, and retention
 - **Storage service** — unified blob I/O across local-disk and S3 backends, scoped to `Files`, `Avatars`, and `Cache`
 
-Worker processes register with the Asynq mux when the server runs in `all` or `worker` mode (`ALCOVES_MODE`). Work is split across three named queues — the single source of truth for queue names and weights is the `internal/queues` package:
+Worker processes register with the Asynq mux when the server runs in `all` or `worker` mode (`ALCOVES_MODE`). Each job type runs on its own named queue — the single source of truth for queue names and weights is the `internal/queues` package. Weights follow **importance ÷ complexity**: how much a user is blocked on the result, divided by how long the job takes (so a heavy job class never hogs the worker pool ahead of fast ones).
 
 | Queue | Weight | Carries |
 |---|---|---|
-| `imageproxy` | 10 | Interactive, on-demand image transforms (a user is blocked on these) |
-| `default` | 3 | Hashing, metadata/EXIF, waveforms, face/object/audio detection, transcription, video transcode, moment export |
-| `maintenance` | 1 | Low-priority background upkeep — currently the hourly image-proxy variant pre-warm |
+| `imageproxy` | 100 | Interactive, on-demand image transforms (a user is blocked on these) |
+| `metadata` | 70 | EXIF/GPS + ffprobe extraction (fast; unblocks Timeline, Map, file details) |
+| `thumbnail` | 65 | Video poster-frame extraction (fast ffmpeg seek) |
+| `hash` | 60 | SHA-256 content hashing for dedup |
+| `default` | 50 | Retained only as a drain target for tasks enqueued by an older build during an upgrade; no new work routes here |
+| `moment-export` | 45 | User-initiated clip encodes |
+| `waveform` | 40 | Audio waveform peaks |
+| `object-detection` | 30 | YOLO ONNX inference (background) |
+| `face-detection` | 30 | Face ONNX inference + clustering (background) |
+| `audio-detection` | 25 | AudioSet ONNX inference (background) |
+| `video-transcode` | 10 | Full video proxy transcodes — heavy, multi-minute ffmpeg work |
+| `transcription` | 5 | Whisper speech-to-text — the longest-running job class |
+| `maintenance` | 1 | Low-priority background upkeep — the hourly image-proxy variant pre-warm |
 
-The weights mean "users first, batch second, upkeep last": a large pre-warm or detection backlog can never starve interactive image loads.
+The ladder means "interactive first, fast derivations next, then ML inference, then the heavy long-runners, with upkeep last": a large transcription or video-transcode backlog can never starve interactive image loads or fast jobs like thumbnailing. Asynq samples non-strictly across non-empty queues in proportion to these weights, so a low-priority queue still drains fully when it's the only one with work.
 
 ---
 

--- a/website/src/content/docs/features/admin-and-job-queue.md
+++ b/website/src/content/docs/features/admin-and-job-queue.md
@@ -135,14 +135,35 @@ is happening in real time and intervene when something goes wrong.
 
 ### Named queues
 
-Jobs are split across three named queues so latency-sensitive work is never
-stuck behind a backlog. You can filter the dashboard by queue:
+Each job type runs on its own named queue, ranked by **importance ÷
+complexity** — how much a user is actively waiting on the result, weighed
+against how long the job takes so a slow job class can never hog the worker
+pool ahead of fast ones. Latency-sensitive work is never stuck behind a
+backlog, and the heaviest long-runners (whisper transcription, full video
+transcode) sit near the bottom — below fast jobs like thumbnailing. You can
+filter the dashboard by queue:
 
 | Queue | Priority | What it carries |
 |---|---|---|
 | `imageproxy` | Highest | Interactive, on-demand image transforms a user is waiting on |
-| `default` | Normal | Detection, transcription, transcode, waveforms, hashing, metadata, moment export |
+| `metadata` | Very high | EXIF/GPS + ffprobe extraction (fast; unblocks Timeline, Map, file details) |
+| `thumbnail` | High | Video poster-frame extraction (fast ffmpeg seek; makes the grid usable) |
+| `hash` | High | SHA-256 content hashing for dedup (fast) |
+| `moment-export` | Medium | User-initiated clip encodes — someone clicked "export" and is waiting |
+| `waveform` | Medium | Audio waveform peaks for the editor/player |
+| `object-detection` | Medium-low | YOLO ONNX inference (background search enrichment) |
+| `face-detection` | Medium-low | Face ONNX inference + clustering (background) |
+| `audio-detection` | Medium-low | AudioSet ONNX inference (background) |
+| `video-transcode` | Low | Full video proxy transcodes — heavy, multi-minute ffmpeg work |
+| `transcription` | Lowest (real work) | Whisper speech-to-text — the longest-running job class |
 | `maintenance` | Lowest | Background upkeep — the hourly image-proxy variant pre-warm |
+
+A `default` queue is retained only as a drain target for tasks enqueued by an
+older build during an upgrade; no current job type routes new work to it.
+
+Queue selection is **non-strict weighted sampling**: a lower-priority queue is
+never starved when it's the only one with work — it simply yields to
+higher-priority queues while they have a backlog.
 
 ### Periodic maintenance jobs
 


### PR DESCRIPTION
## What & why

Heavy, long-running jobs (whisper transcription, full video transcode) used to share the **`default`** queue with everything except interactive image transforms. That meant a multi-minute transcription could sit ahead of a fast thumbnail or metadata job and starve interactive work.

This change gives **each job type its own named queue**, ranked by **importance ÷ complexity**:
- *importance* — how much a user is actively blocked on the result
- *complexity* — how long/heavy the job is (so a slow class can't hog the worker pool ahead of fast ones)

## Ranking (high → low priority)

| Queue | Weight | Carries |
|---|---|---|
| `imageproxy` | 100 | Interactive, on-demand image transforms (user blocked) |
| `metadata` | 70 | EXIF/GPS + ffprobe (fast; unblocks Timeline/Map/details) |
| `thumbnail` | 65 | Video poster-frame extraction (fast ffmpeg seek) |
| `hash` | 60 | SHA-256 dedup hash |
| `default` | 50 | **Drain-only** fallback for tasks enqueued by an older build mid-upgrade |
| `moment-export` | 45 | User-initiated clip encodes |
| `waveform` | 40 | Audio waveform peaks |
| `object-detection` | 30 | YOLO ONNX (background) |
| `face-detection` | 30 | Face ONNX + clustering (background) |
| `audio-detection` | 25 | AudioSet ONNX (background) |
| `video-transcode` | 10 | Full video proxy transcode (heavy, multi-minute) |
| `transcription` | 5 | whisper.cpp speech-to-text (longest-running class) |
| `maintenance` | 1 | Hourly image-proxy variant pre-warm |

This satisfies the explicit asks: **transcription and heavy video transcode get their own lower-priority queues, and whisper sits below thumbnailing.**

## Notes

- Worker selection stays **non-strict weighted sampling** — a low-priority queue still drains fully when it's the only one with work; it only yields while higher-priority queues have a backlog.
- `default` is kept in the priority map purely so tasks enqueued by an older binary during a rolling upgrade still drain. No current code routes new work there (asserted by the routing test).
- The admin job dashboard discovers queues dynamically via the Asynq inspector, so **no frontend change is needed** — the new queues show up automatically.

## Tests

- `internal/queues` — unit test pinning the ranking ladder and the explicit constraints (`transcription < thumbnail`, `video-transcode < thumbnail`, `transcription <= video-transcode`, imageproxy highest, maintenance lowest).
- `internal/queuerouting` — hermetic miniredis integration test asserting **every** enqueue helper lands on its intended queue and nothing leaks to `default`.
- Fixed two existing tests that assumed the `default` queue / an unqualified uniqueness key.
- Full backend suite green: `go test ./...` → 30 packages ok, 0 failures (also ran touched packages with `-race`).

## Docs

Updated the named-queue tables in the admin panel, media-processing-pipeline, and backend-architecture docs pages.