### PR TITLE
fix(security): zip-slip, share-link host spoofing, hardcoded dev PAT

### DIFF
--- a/backend/internal/handlers/download.go
+++ b/backend/internal/handlers/download.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -136,7 +137,7 @@ func (h *DownloadHandler) Download(c echo.Context) error {
 			continue // skip files that can't be read
 		}
 
-		w, err := zipWriter.Create(file.Name)
+		w, err := zipWriter.Create(safeZipName(file.Name))
 		if err != nil {
 			reader.Close()
 			continue
@@ -147,6 +148,23 @@ func (h *DownloadHandler) Download(c echo.Context) error {
 	}
 
 	return nil
+}
+
+// safeZipName sanitizes an attacker-controlled file name (file.Name is set from
+// tus upload metadata and from the rename handler with no path validation) for
+// use as a zip entry path. Without this, a name like "../../../.ssh/authorized_keys"
+// is written verbatim into the archive and a victim extracting it with a
+// non-hardening unzip would have bytes written outside the extraction directory
+// (zip slip). We collapse to the final path element so no traversal survives.
+func safeZipName(name string) string {
+	name = strings.ReplaceAll(name, "\\", "/")
+	// path.Clean on an absolute path resolves any ".." away; Base then takes the
+	// final element, so "/../../etc/passwd" -> "/etc/passwd" -> "passwd".
+	name = path.Base(path.Clean("/" + name))
+	if name == "." || name == "/" || name == "" {
+		return "file"
+	}
+	return name
 }
 
 // Public file proxy handler

--- a/backend/internal/handlers/download_test.go
+++ b/backend/internal/handlers/download_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -838,5 +839,30 @@ func TestParseTransformOptions_DimensionClamped(t *testing.T) {
 				t.Errorf("height: expected %d, got %d", tt.expectedHeight, opts.Height)
 			}
 		})
+	}
+}
+
+func TestSafeZipName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"photo.jpg", "photo.jpg"},
+		{"a/b/c.txt", "c.txt"},
+		{"../../../../etc/passwd", "passwd"},
+		{"..\\..\\windows\\system32\\cmd.exe", "cmd.exe"},
+		{"/.ssh/authorized_keys", "authorized_keys"},
+		{"..", "file"},
+		{"", "file"},
+		{"/", "file"},
+		{"....//evil", "evil"},
+	}
+	for _, tc := range cases {
+		if got := safeZipName(tc.in); got != tc.want {
+			t.Errorf("safeZipName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+		if strings.Contains(safeZipName(tc.in), "..") || strings.ContainsAny(safeZipName(tc.in), "/\\") {
+			t.Errorf("safeZipName(%q) = %q still contains traversal", tc.in, safeZipName(tc.in))
+		}
 	}
 }

--- a/backend/internal/handlers/moment_share.go
+++ b/backend/internal/handlers/moment_share.go
@@ -162,19 +162,30 @@ func generateShareToken() (string, error) {
 }
 
 // baseURLFor resolves the public-facing base URL for the current request.
+//
+// The persisted/returned share link and its OG tags must not be controllable by
+// request headers: both Origin and X-Forwarded-Host are client/proxy-supplied and
+// would otherwise let an attacker mint share URLs pointing at an attacker host.
+// The operator-configured ALCOVES_BASE_URL is therefore trusted first; the headers
+// are only a fallback for deployments that have not configured a base URL.
+//
 // Order:
-//   1. Origin header  — browsers set this on fetch(). Most reliable for our SPA.
-//   2. X-Forwarded-Proto + X-Forwarded-Host — reverse proxies / tunnels.
-//   3. cfg.BaseURL (ALCOVES_BASE_URL).
-//   4. request scheme + Host — last resort, may be internal docker hostname.
+//  1. cfg.BaseURL (ALCOVES_BASE_URL) — trusted operator config.
+//  2. Origin header — fallback for SPA dev with no configured base URL.
+//  3. X-Forwarded-Proto + X-Forwarded-Host — reverse proxies / tunnels.
+//  4. request scheme + Host — last resort, may be internal docker hostname.
 func (h *MomentHandler) baseURLFor(c echo.Context) string {
 	req := c.Request()
+
+	if h.baseURL != "" {
+		return strings.TrimRight(h.baseURL, "/")
+	}
 
 	if origin := strings.TrimSpace(req.Header.Get("Origin")); origin != "" && origin != "null" {
 		return strings.TrimRight(origin, "/")
 	}
 
-	if fwdHost := strings.TrimSpace(req.Header.Get("X-Forwarded-Host")); fwdHost != "" {
+	if fwdHost := safeForwardedHost(req.Header.Get("X-Forwarded-Host")); fwdHost != "" {
 		proto := strings.TrimSpace(req.Header.Get("X-Forwarded-Proto"))
 		if proto == "" {
 			proto = c.Scheme()
@@ -183,10 +194,6 @@ func (h *MomentHandler) baseURLFor(c echo.Context) string {
 			proto = "http"
 		}
 		return proto + "://" + fwdHost
-	}
-
-	if h.baseURL != "" {
-		return strings.TrimRight(h.baseURL, "/")
 	}
 
 	scheme := c.Scheme()

--- a/backend/internal/handlers/moment_share_test.go
+++ b/backend/internal/handlers/moment_share_test.go
@@ -45,10 +45,15 @@ func TestMomentHandler_baseURLFor_Priority(t *testing.T) {
 		fwdHost string
 		want    string
 	}{
-		{name: "Origin header wins", baseURL: "https://cfg", host: "h", origin: "https://web.example.com", want: "https://web.example.com"},
-		{name: "Origin null falls through", baseURL: "https://cfg", host: "h", origin: "null", want: "https://cfg"},
-		{name: "X-Forwarded next", baseURL: "https://cfg", host: "h", fwdHost: "tunnel.example.com", want: "http://tunnel.example.com"},
-		{name: "config when none", baseURL: "https://cfg.example.com/", host: "h", want: "https://cfg.example.com"},
+		// Config wins over attacker-controllable headers (Origin / X-Forwarded-Host)
+		// so share links + OG tags cannot be pointed at an attacker host.
+		{name: "config beats Origin", baseURL: "https://cfg", host: "h", origin: "https://web.example.com", want: "https://cfg"},
+		{name: "config beats X-Forwarded-Host", baseURL: "https://cfg", host: "h", fwdHost: "tunnel.example.com", want: "https://cfg"},
+		{name: "config trailing slash trimmed", baseURL: "https://cfg.example.com/", host: "h", want: "https://cfg.example.com"},
+		// Headers are only consulted as a fallback when no base URL is configured.
+		{name: "Origin fallback when no config", host: "h", origin: "https://web.example.com", want: "https://web.example.com"},
+		{name: "Origin null falls through to host", host: "h", origin: "null", want: "http://h"},
+		{name: "X-Forwarded-Host fallback when no config", host: "h", fwdHost: "tunnel.example.com", want: "http://tunnel.example.com"},
 		{name: "host fallback", host: "fallback:3001", want: "http://fallback:3001"},
 	}
 	for _, tc := range cases {

--- a/backend/internal/handlers/share.go
+++ b/backend/internal/handlers/share.go
@@ -232,9 +232,20 @@ func (h *ShareHandler) Thumbnail(c echo.Context) error {
 }
 
 // resolveBase picks the user-facing origin used when building share URLs.
+//
+// The operator-configured ALCOVES_BASE_URL is trusted first. X-Forwarded-Host is
+// attacker-controllable (any client can send it) and this value is reflected into
+// the public share endpoint's OG/Twitter meta tags, so preferring the header over
+// config would let an attacker mint legitimate-looking share links whose previews
+// and click targets resolve to an attacker host. The header is therefore only a
+// fallback for deployments that have not set a base URL, and is validated to be a
+// bare host[:port] with no scheme/path/control characters.
 func (h *ShareHandler) resolveBase(c echo.Context) string {
 	req := c.Request()
-	if fwdHost := strings.TrimSpace(req.Header.Get("X-Forwarded-Host")); fwdHost != "" {
+	if h.baseURL != "" {
+		return strings.TrimRight(h.baseURL, "/")
+	}
+	if fwdHost := safeForwardedHost(req.Header.Get("X-Forwarded-Host")); fwdHost != "" {
 		proto := strings.TrimSpace(req.Header.Get("X-Forwarded-Proto"))
 		if proto == "" {
 			proto = c.Scheme()
@@ -244,14 +255,29 @@ func (h *ShareHandler) resolveBase(c echo.Context) string {
 		}
 		return proto + "://" + fwdHost
 	}
-	if h.baseURL != "" {
-		return strings.TrimRight(h.baseURL, "/")
-	}
 	scheme := c.Scheme()
 	if scheme == "" {
 		scheme = "http"
 	}
 	return scheme + "://" + req.Host
+}
+
+// safeForwardedHost validates an X-Forwarded-Host value, returning it only if it
+// is a bare host[:port]. It rejects empty values, comma lists (takes the first),
+// any scheme/path ("/"), and whitespace/control characters so the result cannot
+// carry an arbitrary URL into a constructed origin.
+func safeForwardedHost(raw string) string {
+	host := strings.TrimSpace(raw)
+	if i := strings.IndexByte(host, ','); i >= 0 {
+		host = strings.TrimSpace(host[:i])
+	}
+	if host == "" {
+		return ""
+	}
+	if strings.ContainsAny(host, "/\\ \t\r\n") {
+		return ""
+	}
+	return host
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/backend/internal/handlers/share_extra_test.go
+++ b/backend/internal/handlers/share_extra_test.go
@@ -189,7 +189,10 @@ func TestShare_Thumbnail_UnknownToken(t *testing.T) {
 	}
 }
 
-func TestShare_ResolveBase_ForwardedHost(t *testing.T) {
+func TestShare_ResolveBase_ConfigBeatsForwardedHost(t *testing.T) {
+	// fullShareHandler is configured with baseURL http://share.example.com. A
+	// spoofed X-Forwarded-Host must NOT override it (open-redirect / share-link
+	// spoofing), so the configured base URL wins.
 	h, _, _, _ := fullShareHandler(t)
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -197,8 +200,8 @@ func TestShare_ResolveBase_ForwardedHost(t *testing.T) {
 	req.Header.Set("X-Forwarded-Proto", "https")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	if base := h.resolveBase(c); base != "https://proxy.example.com" {
-		t.Fatalf("got %q", base)
+	if base := h.resolveBase(c); base != "http://share.example.com" {
+		t.Fatalf("got %q, want configured base URL to win", base)
 	}
 }
 

--- a/backend/internal/handlers/share_test.go
+++ b/backend/internal/handlers/share_test.go
@@ -33,9 +33,16 @@ func TestShareHandler_resolveBase(t *testing.T) {
 		fwdProt string
 		want    string
 	}{
-		{name: "x-forwarded headers win", baseURL: "https://config", host: "internal:3001",
-			fwdHost: "share.example.com", fwdProt: "https", want: "https://share.example.com"},
+		// Config wins over the attacker-controllable X-Forwarded-Host header so the
+		// public share endpoint cannot be made to emit attacker-host OG/share URLs.
+		{name: "config beats x-forwarded headers", baseURL: "https://config", host: "internal:3001",
+			fwdHost: "share.example.com", fwdProt: "https", want: "https://config"},
 		{name: "config baseURL when no forwarded", baseURL: "https://config.example.com/", host: "x", want: "https://config.example.com"},
+		// Header is only a fallback when no base URL is configured.
+		{name: "x-forwarded fallback when no config", baseURL: "", host: "internal:3001",
+			fwdHost: "share.example.com", fwdProt: "https", want: "https://share.example.com"},
+		{name: "x-forwarded with path rejected", baseURL: "", host: "internal:3001",
+			fwdHost: "evil.example.com/path", want: "http://internal:3001"},
 		{name: "fallback to host", baseURL: "", host: "fallback.local:3001", want: "http://fallback.local:3001"},
 	}
 	for _, tc := range cases {

--- a/backend/internal/seed/enrichment.go
+++ b/backend/internal/seed/enrichment.go
@@ -1,6 +1,7 @@
 package seed
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -304,6 +305,19 @@ func (s *seeder) addActivity(idName string, lib uuid.UUID, actor *uuid.UUID, act
 func hashToken(token string) string {
 	sum := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(sum[:])
+}
+
+// generateDevToken returns a fresh random personal access token (alc_pat_ +
+// 32 hex chars, 128 bits of entropy). The dev PAT must NOT be a compiled-in
+// constant: a fixed value published in the open-source repo means anyone could
+// authenticate to any seeded-and-reachable instance. A per-seed random token,
+// printed once to the seed log, keeps the dev convenience without that risk.
+func generateDevToken() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return "alc_pat_" + hex.EncodeToString(buf), nil
 }
 
 func (s *seeder) addPAT(idName string, user uuid.UUID, name, plaintext string, createdAt time.Time) {

--- a/backend/internal/seed/seed.go
+++ b/backend/internal/seed/seed.go
@@ -36,9 +36,6 @@ const (
 	BobEmail   = "bob@alcoves.io"
 	// DefaultPassword is the plaintext password shared by every seeded account.
 	DefaultPassword = "password123"
-	// DevAccessToken is a fixed personal access token plaintext for the admin
-	// account, handy for poking the MCP server / API from the CLI in local dev.
-	DevAccessToken = "alc_pat_localdev0000000000000000000000000000"
 )
 
 // seedNS namespaces deterministic (v5) UUIDs so re-seeding a wiped DB reuses the
@@ -66,6 +63,10 @@ type Result struct {
 	Objects    int
 	Moments    int
 	Activities int
+	// AccessToken is the freshly-generated plaintext dev PAT for the admin
+	// account. It is only returned here (and logged once by MaybeRun) — there is
+	// no compiled-in constant — so callers/tests read the value from the run.
+	AccessToken string
 }
 
 // MaybeRun seeds dev/test data when enabled and the database is empty.
@@ -122,6 +123,7 @@ func MaybeRun(db *gorm.DB, st *storage.Service, enabled bool, mode, environment 
 	log.Printf("seed: done — %d users, %d libraries, %d folders, %d files, %d tags, %d people, %d faces, %d objects, %d moments, %d activities",
 		res.Users, res.Libraries, res.Folders, res.Files, res.Tags, res.People, res.Faces, res.Objects, res.Moments, res.Activities)
 	log.Printf("seed: log in with %s / %s (owner/admin)", AdminEmail, DefaultPassword)
+	log.Printf("seed: dev personal access token (admin): %s", res.AccessToken)
 	return nil
 }
 
@@ -200,9 +202,15 @@ func (s *seeder) run() error {
 	s.seedTravel(travel, admin, alice)
 	s.seedPodcast(podcast, admin, bob)
 
-	// A fixed personal access token for the admin account, for poking the MCP
-	// server / API from the CLI in local dev.
-	s.addPAT("pat/admin", admin.ID, "Local Dev Token", DevAccessToken, s.ago(10*24*time.Hour))
+	// A freshly-generated personal access token for the admin account, for poking
+	// the MCP server / API from the CLI in local dev. Random per seed (never a
+	// compiled-in constant) and surfaced via Result.AccessToken + the seed log.
+	token, err := generateDevToken()
+	if err != nil {
+		return s.fail(fmt.Errorf("generate dev token: %w", err))
+	}
+	s.res.AccessToken = token
+	s.addPAT("pat/admin", admin.ID, "Local Dev Token", token, s.ago(10*24*time.Hour))
 
 	return s.err
 }

--- a/backend/internal/seed/seed_test.go
+++ b/backend/internal/seed/seed_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gorm.io/gorm"
@@ -162,9 +163,13 @@ func TestRun(t *testing.T) {
 		t.Errorf("share count = %d, want 1", shareCount)
 	}
 
-	// Dev PAT stored as a hash of the known plaintext.
+	// Dev PAT is randomly generated per seed (no compiled-in constant), returned
+	// via Result, and stored as a hash of that plaintext.
+	if !strings.HasPrefix(res.AccessToken, "alc_pat_") {
+		t.Errorf("dev access token = %q, want alc_pat_ prefix", res.AccessToken)
+	}
 	var patCount int64
-	db.Model(&models.PersonalAccessToken{}).Where("token_hash = ?", hashToken(DevAccessToken)).Count(&patCount)
+	db.Model(&models.PersonalAccessToken{}).Where("token_hash = ?", hashToken(res.AccessToken)).Count(&patCount)
 	if patCount != 1 {
 		t.Errorf("dev PAT count = %d, want 1", patCount)
 	}
@@ -240,4 +245,21 @@ func TestMaybeRunGating(t *testing.T) {
 			t.Errorf("users after re-run = %d, want %d (no-op)", n, first)
 		}
 	})
+}
+
+func TestGenerateDevToken(t *testing.T) {
+	a, err := generateDevToken()
+	if err != nil {
+		t.Fatalf("generateDevToken: %v", err)
+	}
+	if !strings.HasPrefix(a, "alc_pat_") {
+		t.Errorf("token %q missing alc_pat_ prefix", a)
+	}
+	if len(a) != len("alc_pat_")+32 {
+		t.Errorf("token %q wrong length %d", a, len(a))
+	}
+	b, _ := generateDevToken()
+	if a == b {
+		t.Error("two generated tokens are identical; not random")
+	}
 }


### PR DESCRIPTION
## Summary

Fixes the three highest-value findings from a threat hunt (5 scanner agents by attack surface + 1 ranking pass). All confirmed, all in the Go backend.

| # | Severity | Vuln | Location |
|---|----------|------|----------|
| 1 | high | **Zip-slip** — user-controlled `file.Name` written verbatim into bulk-download zip entries; `../../.ssh/authorized_keys` escapes the victim's extraction dir | `backend/internal/handlers/download.go` |
| 2 | high | **Open redirect / share-link spoofing** — public base URL (share links + OG/Twitter meta) built from attacker-controllable `X-Forwarded-Host` in preference to configured `ALCOVES_BASE_URL` | `backend/internal/handlers/share.go` |
| 3 | high | Same root cause via `Origin` + `X-Forwarded-Host` on the moment-share path | `backend/internal/handlers/moment_share.go` |
| 4 | high | **Hardcoded dev PAT** — a fixed owner-level token compiled into every build; anyone reading the open-source repo could auth to any seeded-and-reachable instance | `backend/internal/seed/seed.go` |

## Fixes

- **Zip-slip:** new `safeZipName()` normalizes separators and collapses each entry to its final path element, so no `..` traversal survives into the archive.
- **Host spoofing:** `resolveBase` / `baseURLFor` now trust the operator-configured `ALCOVES_BASE_URL` first. `Origin` / `X-Forwarded-Host` are consulted only as a fallback when no base URL is configured, and `X-Forwarded-Host` is validated to a bare `host[:port]` (no scheme / path / CRLF) via `safeForwardedHost()`. Prod sets `ALCOVES_BASE_URL` (required for OAuth + share links), so this closes the spoof there while leaving header-based dev fallback intact.
- **Dev PAT:** generated randomly per seed via `crypto/rand`, surfaced through `Result.AccessToken`, and logged once on boot. The compiled-in constant is removed.

## Tests

- New `TestSafeZipName` (traversal payloads) and `TestGenerateDevToken` (prefix/length/randomness), both DB-free.
- Precedence tests in `share_test.go` / `share_extra_test.go` / `moment_share_test.go` previously asserted the **insecure** header-wins behavior — updated to assert config-wins, with new fallback + path-rejection cases. `seed_test.go::TestRun` now asserts the random token round-trips.
- `go build ./...`, `go vet`, `go test ./...` all green; `-race` clean on `internal/handlers` + `internal/seed`. (DB-backed tests skip locally — no postgres; they run in CI.)

## Notes / follow-ups (not in this PR)

Lower-ranked findings left for separate work: Content-Disposition quote-breakout (`signed.go`/`file.go`), unenforced session-secret length, no TUS upload cap, missing security headers, never-expiring share tokens, no rate limiting, login timing enumeration. The seeded `password123` dev login is intentionally retained (heavily documented, gated to `ALCOVES_SEED` + empty DB + non-production).