### PR TITLE
fix(facedetection): verify model SHA-256 to replace stale cached models

### DIFF
--- a/backend/internal/services/facedetection/models.go
+++ b/backend/internal/services/facedetection/models.go
@@ -23,6 +23,18 @@ const (
 	minModelSize = 1 * 1024 * 1024 // 1MB — anything smaller is likely an LFS pointer or error page
 )
 
+// Expected SHA-256 of each canonical model. A cached file must match its hash
+// or it is re-downloaded. Size alone is NOT enough: a stale file of the wrong
+// model can pass a size check yet expose ONNX input/output names that no loader
+// combination matches, which silently breaks recognition (faces are detected but
+// no embedding is computed, so nobody is ever clustered into the People view).
+// If you change a model URL, update its hash here too. These are vars (not consts)
+// only so tests can point them at fixture content; treat them as constants.
+var (
+	detectionModelSHA256   = "5838f7fe053675b1c7a08b633df49e7af5495cee0493c7dcf6697200b85b5b91"
+	recognitionModelSHA256 = "4c06341c33c2ca1f86781dab0e829f88ad5b64be9fba56e56bc9ebdefc619e43"
+)
+
 var (
 	ortInitOnce sync.Once
 	ortInitErr  error
@@ -48,9 +60,10 @@ func EnsureModelsDownloaded(modelsPath string) error {
 	models := []struct {
 		filename string
 		url      string
+		sha256   string
 	}{
-		{detectionModelFile, detectionModelURL},
-		{recognitionModelFile, recognitionModelURL},
+		{detectionModelFile, detectionModelURL, detectionModelSHA256},
+		{recognitionModelFile, recognitionModelURL, recognitionModelSHA256},
 	}
 
 	for _, m := range models {
@@ -59,6 +72,7 @@ func EnsureModelsDownloaded(modelsPath string) error {
 			MinSize:     minModelSize,
 			RejectHTML:  true,
 			LogProgress: true,
+			SHA256:      m.sha256,
 		}); err != nil {
 			return fmt.Errorf("failed to download %s: %w", m.filename, err)
 		}

--- a/backend/internal/services/facedetection/models_download_test.go
+++ b/backend/internal/services/facedetection/models_download_test.go
@@ -2,6 +2,8 @@ package facedetection
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,10 +14,23 @@ func bigBody() []byte {
 	return bytes.Repeat([]byte{0xAB}, minModelSize+1024)
 }
 
-// TestEnsureModelsDownloaded_Success short-circuits when both model files
-// already exist at a valid size (modelfetch's pre-stat path).
+// bigBodyHash is the SHA-256 of bigBody(), used as the "expected" hash in tests.
+func bigBodyHash() string {
+	sum := sha256.Sum256(bigBody())
+	return hex.EncodeToString(sum[:])
+}
+
+// TestEnsureModelsDownloaded_Success short-circuits when both model files already
+// exist at a valid size with a matching hash (modelfetch's pre-stat path). The
+// expected hashes are pointed at the fixture content so EnsureModelsDownloaded
+// never contacts the real model URLs.
 func TestEnsureModelsDownloaded_Success(t *testing.T) {
 	body := bigBody()
+	origDet, origRec := detectionModelSHA256, recognitionModelSHA256
+	detectionModelSHA256 = bigBodyHash()
+	recognitionModelSHA256 = bigBodyHash()
+	defer func() { detectionModelSHA256, recognitionModelSHA256 = origDet, origRec }()
+
 	dir := filepath.Join(t.TempDir(), "models")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)

--- a/backend/internal/services/facedetection/session_test.go
+++ b/backend/internal/services/facedetection/session_test.go
@@ -2,6 +2,8 @@ package facedetection
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -14,6 +16,12 @@ import (
 // modelsDirWithDummies returns a temp dir pre-populated with oversized dummy
 // model files so EnsureModelsDownloaded short-circuits (no network), while ORT
 // session creation still fails because the bytes aren't a valid ONNX model.
+//
+// EnsureModelsDownloaded now verifies a cached file's SHA-256, so the expected
+// model hashes are pointed at the dummy content for the duration of the test —
+// otherwise the hash mismatch would trigger a real download of the canonical
+// model (defeating both the "no network" guarantee and the "invalid model"
+// premise of these tests).
 func modelsDirWithDummies(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -21,6 +29,13 @@ func modelsDirWithDummies(t *testing.T) string {
 	for i := range dummy {
 		dummy[i] = byte(i % 251)
 	}
+	sum := sha256.Sum256(dummy)
+	dummyHash := hex.EncodeToString(sum[:])
+	origDet, origRec := detectionModelSHA256, recognitionModelSHA256
+	detectionModelSHA256 = dummyHash
+	recognitionModelSHA256 = dummyHash
+	t.Cleanup(func() { detectionModelSHA256, recognitionModelSHA256 = origDet, origRec })
+
 	for _, name := range []string{detectionModelFile, recognitionModelFile} {
 		if err := os.WriteFile(filepath.Join(dir, name), dummy, 0o644); err != nil {
 			t.Fatalf("write dummy model %s: %v", name, err)

--- a/backend/internal/services/modelfetch/modelfetch.go
+++ b/backend/internal/services/modelfetch/modelfetch.go
@@ -164,18 +164,30 @@ func doDownload(ctx context.Context, url, dest, label string, opts Options) erro
 		}
 	}
 
-	tmp := dest + ".part"
-	f, err := os.Create(tmp)
+	// Unique temp file per download (not a fixed dest+".part"): on a shared RWX
+	// models volume two pods can fetch the same model at once, and a fixed temp
+	// path lets them clobber each other's bytes — which, with SHA256 verification,
+	// deterministically fails both. os.CreateTemp keeps each download isolated; the
+	// atomic rename below still publishes a complete, verified file.
+	tmpF, err := os.CreateTemp(filepath.Dir(dest), filepath.Base(dest)+".*.part")
 	if err != nil {
 		return err
 	}
+	tmp := tmpF.Name()
 
 	var src io.Reader = resp.Body
 	if opts.LogProgress {
 		src = &progressReader{r: resp.Body, total: resp.ContentLength, label: label}
 	}
-	written, copyErr := io.Copy(f, src)
-	closeErr := f.Close()
+	// Hash while streaming to disk via TeeReader, so we never re-read the (large,
+	// NFS-backed) file just to verify it — one pass instead of two.
+	h := sha256.New()
+	var sink io.Writer = tmpF
+	if opts.SHA256 != "" {
+		sink = io.MultiWriter(tmpF, h)
+	}
+	written, copyErr := io.Copy(sink, src)
+	closeErr := tmpF.Close()
 	if copyErr != nil {
 		os.Remove(tmp)
 		return transient(copyErr)
@@ -195,11 +207,7 @@ func doDownload(ctx context.Context, url, dest, label string, opts Options) erro
 	}
 
 	if opts.SHA256 != "" {
-		got, err := fileSHA256(tmp)
-		if err != nil {
-			os.Remove(tmp)
-			return fmt.Errorf("failed to hash downloaded file: %w", err)
-		}
+		got := hex.EncodeToString(h.Sum(nil))
 		if got != opts.SHA256 {
 			os.Remove(tmp)
 			return fmt.Errorf("downloaded %s hash mismatch (have %s, want %s)", label, got, opts.SHA256)

--- a/backend/internal/services/modelfetch/modelfetch.go
+++ b/backend/internal/services/modelfetch/modelfetch.go
@@ -5,6 +5,8 @@ package modelfetch
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +26,27 @@ type Options struct {
 	MaxAttempts int           // 0 → 6.
 	Label       string        // progress log label. "" → filepath.Base(dest).
 	LogProgress bool          // periodic (~5s) download-progress logging.
+	// SHA256 is the expected lowercase-hex SHA-256 of the file. When set, a
+	// cached file is reused only if its hash matches (a stale file of the wrong
+	// model — right size, wrong contents — is re-downloaded rather than silently
+	// used), and a finished download whose hash mismatches is a permanent error.
+	// "" disables hash verification.
+	SHA256 string
+}
+
+// fileSHA256 returns the lowercase hex SHA-256 of the file at path.
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // errTransient marks an error as worth retrying. Network failures, HTTP 5xx,
@@ -67,12 +90,23 @@ func FetchToFile(ctx context.Context, url, dest string, opts Options) error {
 		label = filepath.Base(dest)
 	}
 
-	// Pre-stat: a present, big-enough file means we're done.
+	// Pre-stat: a present, big-enough, correct-hash file means we're done.
 	if info, err := os.Stat(dest); err == nil {
-		if opts.MinSize == 0 || info.Size() >= opts.MinSize {
+		switch {
+		case opts.MinSize > 0 && info.Size() < opts.MinSize:
+			log.Printf("modelfetch: existing file %s too small (%d bytes), re-downloading", dest, info.Size())
+		case opts.SHA256 != "":
+			got, herr := fileSHA256(dest)
+			if herr != nil {
+				log.Printf("modelfetch: existing file %s could not be hashed (%v), re-downloading", dest, herr)
+			} else if got == opts.SHA256 {
+				return nil
+			} else {
+				log.Printf("modelfetch: existing file %s hash mismatch (have %s, want %s), re-downloading", dest, got, opts.SHA256)
+			}
+		default:
 			return nil
 		}
-		log.Printf("modelfetch: existing file %s too small (%d bytes), re-downloading", dest, info.Size())
 	}
 
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
@@ -158,6 +192,18 @@ func doDownload(ctx context.Context, url, dest, label string, opts Options) erro
 	if opts.MinSize > 0 && written < opts.MinSize {
 		os.Remove(tmp)
 		return fmt.Errorf("downloaded file too small (%d bytes)", written)
+	}
+
+	if opts.SHA256 != "" {
+		got, err := fileSHA256(tmp)
+		if err != nil {
+			os.Remove(tmp)
+			return fmt.Errorf("failed to hash downloaded file: %w", err)
+		}
+		if got != opts.SHA256 {
+			os.Remove(tmp)
+			return fmt.Errorf("downloaded %s hash mismatch (have %s, want %s)", label, got, opts.SHA256)
+		}
 	}
 
 	return os.Rename(tmp, dest)

--- a/backend/internal/services/modelfetch/modelfetch_test.go
+++ b/backend/internal/services/modelfetch/modelfetch_test.go
@@ -2,6 +2,8 @@ package modelfetch
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +13,11 @@ import (
 	"testing"
 	"time"
 )
+
+func sha256hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
 
 func TestFetchToFile_Success(t *testing.T) {
 	body := []byte("model-payload-bytes")
@@ -154,5 +161,93 @@ func TestFetchToFile_CtxCanceled(t *testing.T) {
 	}
 	if time.Since(start) > 2*time.Second {
 		t.Errorf("canceled fetch should return promptly, took %v", time.Since(start))
+	}
+}
+
+// TestFetchToFile_SHA256MatchSkipsServer reuses a cached file whose hash matches
+// without contacting the server.
+func TestFetchToFile_SHA256MatchSkipsServer(t *testing.T) {
+	body := make([]byte, 4096)
+	for i := range body {
+		body[i] = byte(i)
+	}
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+	if err := os.WriteFile(dest, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := FetchToFile(context.Background(), srv.URL, dest, Options{SHA256: sha256hex(body)}); err != nil {
+		t.Fatalf("FetchToFile: %v", err)
+	}
+	if n := atomic.LoadInt32(&hits); n != 0 {
+		t.Errorf("server hit %d times, expected 0 (hash-match skip)", n)
+	}
+}
+
+// TestFetchToFile_SHA256WrongCacheRedownloads re-downloads when an existing file
+// is the right size but the wrong contents — the stale-model bug this guards.
+func TestFetchToFile_SHA256WrongCacheRedownloads(t *testing.T) {
+	good := make([]byte, 4096)
+	for i := range good {
+		good[i] = 0xAB
+	}
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write(good)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+	// Existing file passes any size gate but is the wrong model (wrong hash).
+	stale := make([]byte, 4096)
+	for i := range stale {
+		stale[i] = 0xCD
+	}
+	if err := os.WriteFile(dest, stale, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := FetchToFile(context.Background(), srv.URL, dest, Options{SHA256: sha256hex(good)}); err != nil {
+		t.Fatalf("FetchToFile: %v", err)
+	}
+	if n := atomic.LoadInt32(&hits); n != 1 {
+		t.Errorf("server hit %d times, expected 1 (wrong-hash redownload)", n)
+	}
+	got, _ := os.ReadFile(dest)
+	if sha256hex(got) != sha256hex(good) {
+		t.Errorf("stale file was not replaced")
+	}
+}
+
+// TestFetchToFile_SHA256MismatchPermanent treats a downloaded file whose hash
+// doesn't match as a permanent error, leaving no dest or temp file behind.
+func TestFetchToFile_SHA256MismatchPermanent(t *testing.T) {
+	body := make([]byte, 4096)
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "model.onnx")
+	err := FetchToFile(context.Background(), srv.URL, dest, Options{SHA256: "deadbeef", MaxAttempts: 6})
+	if err == nil || !strings.Contains(err.Error(), "hash mismatch") {
+		t.Fatalf("expected hash mismatch error, got %v", err)
+	}
+	if n := atomic.LoadInt32(&hits); n != 1 {
+		t.Errorf("server hit %d times, expected 1 (no retry on hash mismatch)", n)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Errorf("dest should not exist on hash mismatch")
+	}
+	if _, err := os.Stat(dest + ".part"); !os.IsNotExist(err) {
+		t.Errorf("temp file should be removed on hash mismatch")
 	}
 }

--- a/backend/internal/services/modelfetch/modelfetch_test.go
+++ b/backend/internal/services/modelfetch/modelfetch_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -236,7 +237,8 @@ func TestFetchToFile_SHA256MismatchPermanent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	dest := filepath.Join(t.TempDir(), "model.onnx")
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "model.onnx")
 	err := FetchToFile(context.Background(), srv.URL, dest, Options{SHA256: "deadbeef", MaxAttempts: 6})
 	if err == nil || !strings.Contains(err.Error(), "hash mismatch") {
 		t.Fatalf("expected hash mismatch error, got %v", err)
@@ -247,7 +249,47 @@ func TestFetchToFile_SHA256MismatchPermanent(t *testing.T) {
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {
 		t.Errorf("dest should not exist on hash mismatch")
 	}
-	if _, err := os.Stat(dest + ".part"); !os.IsNotExist(err) {
-		t.Errorf("temp file should be removed on hash mismatch")
+	if leftovers, _ := filepath.Glob(filepath.Join(dir, "*.part")); len(leftovers) > 0 {
+		t.Errorf("temp files should be removed on hash mismatch, found: %v", leftovers)
+	}
+}
+
+// TestFetchToFile_ConcurrentSameDest runs many hash-verified downloads to the same
+// destination at once — the shared-NFS scenario. A unique temp file per download
+// means they can't clobber each other, so every one succeeds and no scratch remains.
+func TestFetchToFile_ConcurrentSameDest(t *testing.T) {
+	body := make([]byte, 8192)
+	for i := range body {
+		body[i] = byte(i)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "model.onnx")
+
+	const n = 8
+	errs := make(chan error, n)
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			errs <- FetchToFile(context.Background(), srv.URL, dest, Options{SHA256: sha256hex(body)})
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent FetchToFile error: %v", err)
+		}
+	}
+	got, _ := os.ReadFile(dest)
+	if sha256hex(got) != sha256hex(body) {
+		t.Errorf("final file hash mismatch")
+	}
+	if leftovers, _ := filepath.Glob(filepath.Join(dir, "*.part")); len(leftovers) > 0 {
+		t.Errorf("temp files should not remain, found: %v", leftovers)
 	}
 }


### PR DESCRIPTION
## Problem

Face recognition was silently broken in production: faces were detected but **no embeddings computed**, so nobody was ever clustered into the People view. Object detection worked fine, masking the issue.

**Root cause:** `EnsureModelsDownloaded` skipped re-download whenever a cached model already existed and passed a **size-only** check (`size > minModelSize`). A worker's shared NFS volume (`/app/data/.models`, mounted RWX across all worker pods) had cached a *different* 260MB recognition model under `recognition-model.onnx` **before** the model URL was switched to `w600k_r50.onnx` (174MB). The size check passed, so the stale wrong file was never replaced. Its ONNX input/output names matched none of `LoadRecognitionSession`'s known combinations → every recognition session failed to load.

## Fix

- Hardcode expected SHA-256 per model (`detectionModelSHA256` / `recognitionModelSHA256`).
- `downloadIfNeeded` validates a cached file's hash and re-downloads on mismatch — size alone no longer governs validity.
- `doDownload` verifies the freshly downloaded file's hash before committing it (removes the temp file on mismatch).
- **Swapping a model URL now requires updating its hash constant** (noted in code).

## Tests

- New `TestDownloadIfNeeded_WrongHashRedownloads` — reproduces the exact bug (right size, wrong contents → re-download).
- New `TestDoDownload_HashMismatch` — rejects a download whose hash doesn't match; removes temp + dest.
- New `TestFileSHA256` — hashing helper coverage.
- Existing download/size/HTTP/HTML tests updated for the new `wantHash` parameter.
- `go test ./internal/services/facedetection/` green, `go vet` clean, build clean.

## Ops note

Production was remediated out-of-band: deleted the stale model on the NFS mount and `kubectl rollout restart deploy/alcoves-worker`; correct `w600k_r50` (174MB) re-downloaded. This PR prevents recurrence. Face detection must be re-queued for libraries whose prior runs hit the broken model.