### PR TITLE
feat(queue): reap async jobs stuck in a non-terminal state

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -218,7 +218,15 @@ func main() {
 	var asynqServer *asynq.Server
 	if cfg.Mode == "all" || cfg.Mode == "worker" {
 		asynqServer = asynq.NewServer(asynqRedisOpt, asynq.Config{
-			Concurrency: 8,
+			// Keep per-pod concurrency low. The heavy jobs (whisper, ffmpeg
+			// transcode, ONNX inference) are each RAM- and CPU-hungry, so packing
+			// many into one pod multiplies its peak memory and is what OOM-killed
+			// the pool. To process more in parallel, scale OUT (raise the worker
+			// Deployment's replicaCount) rather than raising this number — more
+			// pods spread the memory across nodes and fail independently, whereas
+			// a higher concurrency concentrates risk in a single pod. Only raise
+			// this if a single worker pod is provisioned with plenty of headroom.
+			Concurrency: 2,
 			// Per-job-type queue weights come from the single source of truth in
 			// the queues package, ranked by importance ÷ complexity: interactive
 			// image transforms ≫ fast post-upload derivations (metadata,

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/alcoves/alcoves-backend/internal/services/filehash"
 	"github.com/alcoves/alcoves-backend/internal/services/files"
 	"github.com/alcoves/alcoves-backend/internal/services/imageproxy"
+	"github.com/alcoves/alcoves-backend/internal/services/jobreaper"
 	"github.com/alcoves/alcoves-backend/internal/services/metadata"
 	"github.com/alcoves/alcoves-backend/internal/services/momentexport"
 	"github.com/alcoves/alcoves-backend/internal/services/objectdetection"
@@ -264,6 +265,13 @@ func main() {
 		} else {
 			log.Println("image:prewarm — disabled via ALCOVES_IMAGE_PROXY_PREWARM_ENABLED=false")
 		}
+
+		// Job reaper: periodically reconcile every async job's status column
+		// against the queue and mark genuinely orphaned jobs (worker died
+		// mid-flight, no task left in Redis) as "failed", clearing rows stuck
+		// forever on "queued"/"processing". Safe for long-runners: a job still
+		// active in the queue is never touched, so there is no wall-clock timeout.
+		jobreaper.Start(context.Background(), db, asynqInspector)
 	}
 
 	// Echo setup

--- a/backend/internal/services/jobreaper/reaper.go
+++ b/backend/internal/services/jobreaper/reaper.go
@@ -10,8 +10,8 @@
 // queue state. A row is considered orphaned only when BOTH hold:
 //
 //   - its status column is non-terminal ("queued"/"processing"), and
-//   - the Asynq inspector reports NO live task (active/pending/scheduled/retry/
-//     aggregating) of the matching type for that entity.
+//   - the Asynq inspector reports NO live task (active/pending/scheduled/retry)
+//     of the matching type for that entity.
 //
 // Using the inspector as the liveness oracle is what makes this safe for
 // genuinely long-running jobs: a multi-hour whisper transcribe is "active" in
@@ -212,7 +212,10 @@ func (s *Service) reapSpec(sp spec) (int, error) {
 }
 
 // candidates returns ids of rows in a non-terminal state that have not been
-// touched for at least reapGrace.
+// touched for at least reapGrace. Oldest-stale first (ORDER BY updated_at): with
+// a bounded batch this guarantees the longest-stuck rows are always recovered
+// rather than being starved by a churn of newer ones, and keeps row selection
+// deterministic across passes.
 func (s *Service) candidates(sp spec) ([]string, error) {
 	var ids []string
 	q := fmt.Sprintf(`
@@ -220,6 +223,7 @@ func (s *Service) candidates(sp spec) ([]string, error) {
 		WHERE %s IN ('queued', 'processing')
 		  AND trashed_at IS NULL
 		  AND updated_at < NOW() - ? * INTERVAL '1 second'
+		ORDER BY updated_at ASC
 		LIMIT ?`, sp.table, sp.statusColumn)
 	err := s.db.Raw(q, int(reapGrace.Seconds()), reapBatch).Scan(&ids).Error
 	return ids, err
@@ -255,7 +259,8 @@ func collectLiveIDs(
 ) error {
 	const pageSize = 500
 	// Bound total pages as a runaway backstop (250 * 500 = 125k tasks per state).
-	for page := 1; page <= 250; page++ {
+	const maxPages = 250
+	for page := 1; page <= maxPages; page++ {
 		tasks, err := list(sp.queue, asynq.PageSize(pageSize), asynq.Page(page))
 		if err != nil {
 			// A queue Redis has never seen yields a wrapped ErrQueueNotFound; that
@@ -274,10 +279,19 @@ func collectLiveIDs(
 			}
 		}
 		if len(tasks) < pageSize {
-			break
+			return nil // last (partial) page reached — liveness set is complete
 		}
 	}
-	return nil
+	// Every page up to the cap came back full, so there are still more live tasks
+	// we haven't seen. Reporting this partial set would let the caller mark
+	// genuinely-live jobs as orphaned, so fail loudly instead: reapSpec turns this
+	// into a logged skip for this pass, leaving the rows untouched until the
+	// backlog drains. (maxPages*pageSize live tasks in one queue is far beyond any
+	// real backlog; this is a safety backstop, not an expected path.)
+	return fmt.Errorf(
+		"liveness set incomplete: queue %q exceeded the %d-task pagination cap; skipping reap to avoid false orphaning",
+		sp.queue, maxPages*pageSize,
+	)
 }
 
 // payloadID extracts a string field from a task's JSON payload, returning "" if

--- a/backend/internal/services/jobreaper/reaper.go
+++ b/backend/internal/services/jobreaper/reaper.go
@@ -1,0 +1,333 @@
+// Package jobreaper recovers async jobs that crashed mid-flight and left a
+// "files"/"moments" status column stuck on a non-terminal value ("queued" or
+// "processing") forever. A worker can die between marking a row in-progress and
+// reaching a terminal state — OOM kill, pod eviction, or asynq exhausting its
+// retries and archiving the task — at which point no task exists in the queue
+// but the database still advertises the job as running. Those rows are the
+// "dirty state": a spinner in the UI that never resolves.
+//
+// The reaper periodically reconciles the database against the *authoritative*
+// queue state. A row is considered orphaned only when BOTH hold:
+//
+//   - its status column is non-terminal ("queued"/"processing"), and
+//   - the Asynq inspector reports NO live task (active/pending/scheduled/retry/
+//     aggregating) of the matching type for that entity.
+//
+// Using the inspector as the liveness oracle is what makes this safe for
+// genuinely long-running jobs: a multi-hour whisper transcribe is "active" in
+// Redis the entire time it runs, so it is never touched no matter how long it
+// has been going — there is no wall-clock timeout that could kill a healthy job.
+// Only rows whose task has truly vanished (asynq archived it after exhausting
+// retries, or it was lost when a worker died uncleanly) are reaped.
+//
+// The recovery action is to mark the row "failed" — a clean terminal state that
+// clears the stuck spinner, surfaces the breakage in the UI, and stays manually
+// retryable. The reaper deliberately does NOT re-enqueue: the dominant cause of
+// orphaning is a poison-pill input that OOM-kills its worker, and blindly
+// re-enqueuing would re-crash the worker pool in a loop. Job classes that have
+// their own bounded-retry backfill (metadata, image pre-warm) keep their rows
+// "live" in the queue while retrying, so the inspector check naturally spares
+// them until they exhaust their own strike cap and settle on a terminal state.
+package jobreaper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hibiken/asynq"
+	"gorm.io/gorm"
+
+	"github.com/alcoves/alcoves-backend/internal/queues"
+)
+
+const (
+	// reaperInterval is how often a reconciliation pass runs. Each pass is a
+	// handful of indexed UPDATEs plus bounded inspector reads, so it is cheap to
+	// run frequently.
+	reaperInterval = 5 * time.Minute
+
+	// reapGrace is how long a row must sit untouched in a non-terminal state
+	// before it is even a candidate. It guards the brief window between a worker
+	// writing "queued"/"processing" and the matching task becoming visible to
+	// the inspector (e.g. a process that committed the status row but died before
+	// enqueuing), so normal in-flight work is never mistaken for an orphan. Note
+	// this is NOT a job timeout: a healthy long-runner is spared by the live-task
+	// check regardless of how stale its row's updated_at is.
+	reapGrace = 15 * time.Minute
+
+	// reapBatch bounds how many candidate rows a single spec scans per pass.
+	reapBatch = 500
+
+	// orphanReason is written to a job's error column (when it has one) so the
+	// UI/admin can tell a reaper recovery apart from a real processing failure.
+	orphanReason = "orphaned: worker terminated before the job completed (recovered by the job reaper)"
+)
+
+// Task-type wire strings, mirrored here to keep the reaper decoupled from the
+// heavyweight worker service packages. reaper_consts_test.go asserts each value
+// stays equal to its canonical constant, so a rename can never silently break
+// the liveness match.
+const (
+	taskTranscribe   = "file:transcribe"
+	taskVideoProxy   = "video:proxy"
+	taskAudioDetect  = "file:audio-detect"
+	taskWaveform     = "file:waveform"
+	taskMomentExport = "moment:export"
+)
+
+// spec describes one reapable job class: where its status lives in the database
+// and how to find its live tasks in the queue.
+type spec struct {
+	name           string // human label for logs
+	queue          string // asynq queue to inspect for live tasks
+	taskType       string // asynq task type to match within that queue
+	table          string // database table holding the status column
+	statusColumn   string // the non-terminal/terminal status column
+	progressColumn string // optional; nulled on reap
+	etaColumn      string // optional; nulled on reap
+	errorColumn    string // optional; set to orphanReason on reap
+	payloadIDField string // JSON field in the task payload holding the entity id
+}
+
+// specs enumerates every async job class that owns a status column on a row and
+// has no other mechanism to clear a crashed-mid-flight non-terminal state.
+//
+// table/column values here are fixed internal identifiers (never user input),
+// so interpolating them into SQL below is not an injection vector.
+var specs = []spec{
+	{
+		name: "transcribe", queue: queues.Transcription, taskType: taskTranscribe,
+		table: "files", statusColumn: "transcribe_status",
+		progressColumn: "transcribe_progress", etaColumn: "transcribe_eta_seconds",
+		errorColumn: "transcribe_error", payloadIDField: "fileId",
+	},
+	{
+		name: "video-proxy", queue: queues.VideoTranscode, taskType: taskVideoProxy,
+		table: "files", statusColumn: "proxy_status",
+		progressColumn: "proxy_progress", etaColumn: "proxy_eta_seconds",
+		errorColumn: "", payloadIDField: "fileId",
+	},
+	{
+		name: "audio-detect", queue: queues.AudioDetection, taskType: taskAudioDetect,
+		table: "files", statusColumn: "audio_detect_status",
+		progressColumn: "audio_detect_progress", etaColumn: "audio_detect_eta_seconds",
+		errorColumn: "audio_detect_error", payloadIDField: "fileId",
+	},
+	{
+		name: "waveform", queue: queues.Waveform, taskType: taskWaveform,
+		table: "files", statusColumn: "waveform_status",
+		progressColumn: "waveform_progress", etaColumn: "",
+		errorColumn: "waveform_error", payloadIDField: "fileId",
+	},
+	{
+		name: "moment-export", queue: queues.MomentExport, taskType: taskMomentExport,
+		table: "moments", statusColumn: "export_status",
+		progressColumn: "export_progress", etaColumn: "export_eta_seconds",
+		errorColumn: "", payloadIDField: "momentId",
+	},
+}
+
+// Service reconciles job status rows against the queue.
+type Service struct {
+	db        *gorm.DB
+	inspector *asynq.Inspector
+}
+
+// NewService builds a reaper bound to a database and an Asynq inspector.
+func NewService(db *gorm.DB, inspector *asynq.Inspector) *Service {
+	return &Service{db: db, inspector: inspector}
+}
+
+// Start launches a background loop that runs a reconciliation pass at boot and
+// then every reaperInterval until ctx is cancelled. It is meant to run only on
+// worker/all nodes (where the inspector and DB are both reachable).
+func Start(ctx context.Context, db *gorm.DB, inspector *asynq.Inspector) {
+	s := NewService(db, inspector)
+	go func() {
+		ticker := time.NewTicker(reaperInterval)
+		defer ticker.Stop()
+
+		s.RunPass(ctx)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.RunPass(ctx)
+			}
+		}
+	}()
+}
+
+// RunPass reaps orphaned jobs for every spec once. Errors are logged per spec so
+// one failing job class never blocks the others.
+func (s *Service) RunPass(ctx context.Context) {
+	for _, sp := range specs {
+		n, err := s.reapSpec(sp)
+		if err != nil {
+			log.Printf("job reaper: %s: %v", sp.name, err)
+			continue
+		}
+		if n > 0 {
+			log.Printf("job reaper: %s: marked %d orphaned job(s) failed", sp.name, n)
+		}
+		if ctx.Err() != nil {
+			return
+		}
+	}
+}
+
+// reapSpec scans one job class for orphans and marks them failed. It returns the
+// number of rows recovered.
+func (s *Service) reapSpec(sp spec) (int, error) {
+	// 1. Candidates: non-terminal and untouched past the grace window.
+	candidates, err := s.candidates(sp)
+	if err != nil {
+		return 0, fmt.Errorf("scan: %w", err)
+	}
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+
+	// 2. Liveness oracle, read AFTER selecting candidates so a task that became
+	//    active in the meantime is in the set and spares its row.
+	live, err := s.liveIDs(sp)
+	if err != nil {
+		return 0, fmt.Errorf("inspect queue %q: %w", sp.queue, err)
+	}
+
+	// 3. Orphans = candidates with no live task of the matching type.
+	orphans := selectOrphans(candidates, live)
+	if len(orphans) == 0 {
+		return 0, nil
+	}
+
+	// 4. Mark failed. The status guard in the UPDATE makes this a no-op for any
+	//    row that reached a terminal state between the scan and now.
+	return s.markFailed(sp, orphans)
+}
+
+// candidates returns ids of rows in a non-terminal state that have not been
+// touched for at least reapGrace.
+func (s *Service) candidates(sp spec) ([]string, error) {
+	var ids []string
+	q := fmt.Sprintf(`
+		SELECT id FROM %s
+		WHERE %s IN ('queued', 'processing')
+		  AND trashed_at IS NULL
+		  AND updated_at < NOW() - ? * INTERVAL '1 second'
+		LIMIT ?`, sp.table, sp.statusColumn)
+	err := s.db.Raw(q, int(reapGrace.Seconds()), reapBatch).Scan(&ids).Error
+	return ids, err
+}
+
+// liveIDs returns the set of entity ids that currently have a live task (active,
+// pending, scheduled, or retrying) of the spec's type in its queue. Archived and
+// completed tasks are intentionally excluded: archived means asynq gave up (the
+// row is orphaned), completed means the job already finished. Aggregating tasks
+// are not listed because no reaped job class enqueues with a group key.
+func (s *Service) liveIDs(sp spec) (map[string]struct{}, error) {
+	live := map[string]struct{}{}
+	listers := []func(string, ...asynq.ListOption) ([]*asynq.TaskInfo, error){
+		s.inspector.ListActiveTasks,
+		s.inspector.ListPendingTasks,
+		s.inspector.ListScheduledTasks,
+		s.inspector.ListRetryTasks,
+	}
+	for _, list := range listers {
+		if err := collectLiveIDs(list, sp, live); err != nil {
+			return nil, err
+		}
+	}
+	return live, nil
+}
+
+// collectLiveIDs paginates a single task lister fully and adds the payload id of
+// every matching-type task to live.
+func collectLiveIDs(
+	list func(string, ...asynq.ListOption) ([]*asynq.TaskInfo, error),
+	sp spec,
+	live map[string]struct{},
+) error {
+	const pageSize = 500
+	// Bound total pages as a runaway backstop (250 * 500 = 125k tasks per state).
+	for page := 1; page <= 250; page++ {
+		tasks, err := list(sp.queue, asynq.PageSize(pageSize), asynq.Page(page))
+		if err != nil {
+			// A queue Redis has never seen yields a wrapped ErrQueueNotFound; that
+			// just means zero live tasks, not a failure.
+			if errors.Is(err, asynq.ErrQueueNotFound) {
+				return nil
+			}
+			return err
+		}
+		for _, t := range tasks {
+			if t.Type != sp.taskType {
+				continue
+			}
+			if id := payloadID(t.Payload, sp.payloadIDField); id != "" {
+				live[id] = struct{}{}
+			}
+		}
+		if len(tasks) < pageSize {
+			break
+		}
+	}
+	return nil
+}
+
+// payloadID extracts a string field from a task's JSON payload, returning "" if
+// the payload is unparseable or the field is missing/non-string.
+func payloadID(payload []byte, field string) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return ""
+	}
+	if v, ok := m[field].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// selectOrphans returns the candidate ids that have no live task.
+func selectOrphans(candidates []string, live map[string]struct{}) []string {
+	orphans := make([]string, 0, len(candidates))
+	for _, id := range candidates {
+		if _, ok := live[id]; !ok {
+			orphans = append(orphans, id)
+		}
+	}
+	return orphans
+}
+
+// markFailed transitions the given rows to "failed", clearing progress/eta and
+// recording the orphan reason. The status guard ensures a row that completed
+// between the scan and now is left untouched.
+func (s *Service) markFailed(sp spec, ids []string) (int, error) {
+	updates := map[string]any{
+		sp.statusColumn: "failed",
+		"updated_at":    gorm.Expr("NOW()"),
+	}
+	if sp.errorColumn != "" {
+		updates[sp.errorColumn] = orphanReason
+	}
+	if sp.progressColumn != "" {
+		updates[sp.progressColumn] = nil
+	}
+	if sp.etaColumn != "" {
+		updates[sp.etaColumn] = nil
+	}
+
+	res := s.db.Table(sp.table).
+		Where("id IN ?", ids).
+		Where(sp.statusColumn+" IN ('queued','processing')").
+		Updates(updates)
+	return int(res.RowsAffected), res.Error
+}

--- a/backend/internal/services/jobreaper/reaper_consts_test.go
+++ b/backend/internal/services/jobreaper/reaper_consts_test.go
@@ -1,0 +1,50 @@
+package jobreaper
+
+import (
+	"testing"
+
+	"github.com/alcoves/alcoves-backend/internal/services/audiodetection"
+	"github.com/alcoves/alcoves-backend/internal/services/momentexport"
+	"github.com/alcoves/alcoves-backend/internal/services/transcribe"
+	"github.com/alcoves/alcoves-backend/internal/services/videoproxy"
+	"github.com/alcoves/alcoves-backend/internal/services/waveform"
+)
+
+// TestTaskTypeConstantsInSync locks the reaper's locally-mirrored task-type wire
+// strings to their canonical definitions in the worker service packages. The
+// reaper matches live tasks by these strings, so a silent rename in a worker
+// package would otherwise make the reaper stop sparing in-flight jobs of that
+// type. If this fails, update the mirrored const in reaper.go to match.
+func TestTaskTypeConstantsInSync(t *testing.T) {
+	cases := []struct {
+		name      string
+		local     string
+		canonical string
+	}{
+		{"transcribe", taskTranscribe, transcribe.TaskTypeTranscribe},
+		{"video-proxy", taskVideoProxy, videoproxy.TaskTypeVideoProxy},
+		{"audio-detect", taskAudioDetect, audiodetection.TaskTypeAudioDetect},
+		{"waveform", taskWaveform, waveform.TaskTypeWaveform},
+		{"moment-export", taskMomentExport, momentexport.TaskTypeMomentExport},
+	}
+	for _, c := range cases {
+		if c.local != c.canonical {
+			t.Errorf("%s: reaper const %q != canonical %q", c.name, c.local, c.canonical)
+		}
+	}
+}
+
+// TestSpecsCoverDistinctTaskTypes guards against a copy-paste slip that points
+// two specs at the same task type or leaves a payload id field blank.
+func TestSpecsCoverDistinctTaskTypes(t *testing.T) {
+	seen := map[string]bool{}
+	for _, sp := range specs {
+		if sp.taskType == "" || sp.payloadIDField == "" || sp.statusColumn == "" || sp.table == "" {
+			t.Errorf("spec %q has an empty required field: %+v", sp.name, sp)
+		}
+		if seen[sp.taskType] {
+			t.Errorf("duplicate spec for task type %q", sp.taskType)
+		}
+		seen[sp.taskType] = true
+	}
+}

--- a/backend/internal/services/jobreaper/reaper_test.go
+++ b/backend/internal/services/jobreaper/reaper_test.go
@@ -1,0 +1,236 @@
+package jobreaper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/alcoves/alcoves-backend/internal/models"
+	"github.com/alcoves/alcoves-backend/internal/testsupport"
+)
+
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }
+
+func specByName(t *testing.T, name string) spec {
+	t.Helper()
+	for _, sp := range specs {
+		if sp.name == name {
+			return sp
+		}
+	}
+	t.Fatalf("no spec named %q", name)
+	return spec{}
+}
+
+func TestSelectOrphans(t *testing.T) {
+	candidates := []string{"a", "b", "c", "d"}
+	live := map[string]struct{}{"b": {}, "d": {}}
+
+	got := selectOrphans(candidates, live)
+	if len(got) != 2 || got[0] != "a" || got[1] != "c" {
+		t.Fatalf("selectOrphans = %v, want [a c]", got)
+	}
+
+	// Nothing live → everything is an orphan.
+	if all := selectOrphans(candidates, map[string]struct{}{}); len(all) != 4 {
+		t.Fatalf("empty live set should orphan all 4, got %v", all)
+	}
+	// All live → nothing reaped.
+	allLive := map[string]struct{}{"a": {}, "b": {}, "c": {}, "d": {}}
+	if none := selectOrphans(candidates, allLive); len(none) != 0 {
+		t.Fatalf("fully-live set should orphan none, got %v", none)
+	}
+}
+
+func TestPayloadID(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		field   string
+		want    string
+	}{
+		{"file id", `{"libraryId":"lib","fileId":"f1"}`, "fileId", "f1"},
+		{"moment id", `{"momentId":"m1","fileId":"f1","libraryId":"lib"}`, "momentId", "m1"},
+		{"missing field", `{"libraryId":"lib"}`, "fileId", ""},
+		{"non-string field", `{"fileId":42}`, "fileId", ""},
+		{"empty payload", ``, "fileId", ""},
+		{"garbage", `not json`, "fileId", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := payloadID([]byte(c.payload), c.field); got != c.want {
+				t.Fatalf("payloadID(%q,%q) = %q, want %q", c.payload, c.field, got, c.want)
+			}
+		})
+	}
+}
+
+// setupReaperTestDB scopes the reaper's global, library-agnostic queries to
+// their own PostgreSQL schema so concurrent test packages don't pollute the scan.
+func setupReaperTestDB(t *testing.T) (*gorm.DB, uuid.UUID) {
+	t.Helper()
+	db := testsupport.OpenSchema(t, "svc_jobreaper")
+	if err := db.AutoMigrate(&models.User{}, &models.Library{}, &models.File{}, &models.Moment{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	db.Exec("DELETE FROM moments")
+	db.Exec("DELETE FROM files")
+	db.Exec("DELETE FROM libraries")
+	db.Exec("DELETE FROM users")
+
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Email: userID.String()[:8] + "@t.com", DisplayName: "U", Role: "owner"})
+	libID := uuid.New()
+	db.Create(&models.Library{ID: libID, Name: "L", OwnerID: userID})
+	return db, libID
+}
+
+// backdate forces updated_at older than the grace window so a row qualifies as a
+// candidate; GORM stamps updated_at = now() on create.
+func backdate(t *testing.T, db *gorm.DB, table, id string) {
+	t.Helper()
+	if err := db.Exec(
+		"UPDATE "+table+" SET updated_at = NOW() - INTERVAL '1 hour' WHERE id = ?", id,
+	).Error; err != nil {
+		t.Fatalf("backdate %s/%s: %v", table, id, err)
+	}
+}
+
+func TestCandidatesAndMarkFailed_Files(t *testing.T) {
+	db, libID := setupReaperTestDB(t)
+	svc := NewService(db, nil) // inspector unused by candidates/markFailed
+	sp := specByName(t, "transcribe")
+
+	mk := func(name string, f models.File) uuid.UUID {
+		f.LibraryID = libID
+		f.Name = name
+		f.MimeType = "video/mp4"
+		f.Size = 1
+		if err := db.Create(&f).Error; err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+		return f.ID
+	}
+	now := time.Now()
+
+	// Stale + non-terminal → candidate.
+	stuck := mk("stuck.mp4", models.File{TranscribeStatus: strPtr("processing"), TranscribeProgress: intPtr(40)})
+	backdate(t, db, "files", stuck.String())
+	queuedStale := mk("queued.mp4", models.File{TranscribeStatus: strPtr("queued")})
+	backdate(t, db, "files", queuedStale.String())
+
+	// Excluded cases.
+	mk("fresh.mp4", models.File{TranscribeStatus: strPtr("processing")})            // within grace
+	mk("done.mp4", models.File{TranscribeStatus: strPtr("ready")})                  // terminal
+	mk("failed.mp4", models.File{TranscribeStatus: strPtr("failed")})               // terminal
+	trashed := mk("trashed.mp4", models.File{TranscribeStatus: strPtr("processing"), TrashedAt: &now}) // trashed
+	backdate(t, db, "files", trashed.String())
+
+	got, err := svc.candidates(sp)
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	set := map[string]bool{}
+	for _, id := range got {
+		set[id] = true
+	}
+	if len(set) != 2 || !set[stuck.String()] || !set[queuedStale.String()] {
+		t.Fatalf("candidates = %v, want {%s, %s}", got, stuck, queuedStale)
+	}
+
+	// markFailed transitions the two stale non-terminal rows (the status-guard
+	// behaviour for already-terminal rows is covered by TestMarkFailed_StatusGuard).
+	n, err := svc.markFailed(sp, []string{stuck.String(), queuedStale.String()})
+	if err != nil {
+		t.Fatalf("markFailed: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("markFailed affected %d rows, want 2", n)
+	}
+
+	var reaped models.File
+	if err := db.First(&reaped, "id = ?", stuck).Error; err != nil {
+		t.Fatal(err)
+	}
+	if reaped.TranscribeStatus == nil || *reaped.TranscribeStatus != "failed" {
+		t.Fatalf("status = %v, want failed", reaped.TranscribeStatus)
+	}
+	if reaped.TranscribeError == nil || *reaped.TranscribeError != orphanReason {
+		t.Fatalf("error = %v, want %q", reaped.TranscribeError, orphanReason)
+	}
+	if reaped.TranscribeProgress != nil {
+		t.Fatalf("progress = %v, want nil (cleared)", *reaped.TranscribeProgress)
+	}
+}
+
+func TestMarkFailed_StatusGuard(t *testing.T) {
+	db, libID := setupReaperTestDB(t)
+	svc := NewService(db, nil)
+	sp := specByName(t, "transcribe")
+
+	// A row that finished between scan and update must NOT be overwritten.
+	done := models.File{LibraryID: libID, Name: "won-the-race.mp4", MimeType: "video/mp4", Size: 1, TranscribeStatus: strPtr("ready")}
+	if err := db.Create(&done).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := svc.markFailed(sp, []string{done.ID.String()})
+	if err != nil {
+		t.Fatalf("markFailed: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("status guard failed: affected %d rows, want 0", n)
+	}
+	var after models.File
+	db.First(&after, "id = ?", done.ID)
+	if after.TranscribeStatus == nil || *after.TranscribeStatus != "ready" {
+		t.Fatalf("terminal row was clobbered: %v", after.TranscribeStatus)
+	}
+}
+
+func TestCandidatesAndMarkFailed_Moments(t *testing.T) {
+	db, libID := setupReaperTestDB(t)
+	svc := NewService(db, nil)
+	sp := specByName(t, "moment-export")
+
+	// A moment needs an owning file.
+	file := models.File{LibraryID: libID, Name: "src.mp4", MimeType: "video/mp4", Size: 1}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	userID := uuid.New()
+	db.Create(&models.User{ID: userID, Email: userID.String()[:8] + "@t.com", DisplayName: "C", Role: "viewer"})
+
+	m := models.Moment{
+		FileID: file.ID, LibraryID: libID, CreatedByID: userID,
+		Name: "clip", StartSeconds: 0, EndSeconds: 5,
+		ExportStatus: strPtr("processing"), ExportProgress: intPtr(10),
+	}
+	if err := db.Create(&m).Error; err != nil {
+		t.Fatal(err)
+	}
+	backdate(t, db, "moments", m.ID.String())
+
+	got, err := svc.candidates(sp)
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	if len(got) != 1 || got[0] != m.ID.String() {
+		t.Fatalf("candidates = %v, want {%s}", got, m.ID)
+	}
+
+	if _, err := svc.markFailed(sp, got); err != nil {
+		t.Fatalf("markFailed: %v", err)
+	}
+	var after models.Moment
+	db.First(&after, "id = ?", m.ID)
+	if after.ExportStatus == nil || *after.ExportStatus != "failed" {
+		t.Fatalf("status = %v, want failed", after.ExportStatus)
+	}
+	if after.ExportProgress != nil {
+		t.Fatalf("progress = %v, want nil", *after.ExportProgress)
+	}
+}

--- a/backend/internal/services/jobreaper/reaper_test.go
+++ b/backend/internal/services/jobreaper/reaper_test.go
@@ -1,15 +1,78 @@
 package jobreaper
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hibiken/asynq"
 	"gorm.io/gorm"
 
 	"github.com/alcoves/alcoves-backend/internal/models"
 	"github.com/alcoves/alcoves-backend/internal/testsupport"
 )
+
+// TestCollectLiveIDs_CompletePage: a single partial page ends pagination and the
+// matching-type payload ids land in the live set (wrong-type tasks are skipped).
+func TestCollectLiveIDs_CompletePage(t *testing.T) {
+	sp := specByName(t, "transcribe")
+	calls := 0
+	list := func(_ string, _ ...asynq.ListOption) ([]*asynq.TaskInfo, error) {
+		calls++
+		return []*asynq.TaskInfo{
+			{Type: sp.taskType, Payload: []byte(`{"fileId":"f1"}`)},
+			{Type: "file:other", Payload: []byte(`{"fileId":"f2"}`)}, // wrong type, ignored
+		}, nil
+	}
+	live := map[string]struct{}{}
+	if err := collectLiveIDs(list, sp, live); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := live["f1"]; !ok || len(live) != 1 {
+		t.Fatalf("live = %v, want {f1}", live)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 page call, got %d", calls)
+	}
+}
+
+// TestCollectLiveIDs_PaginationCapErrors: when every page comes back full the
+// liveness set is incomplete, so collectLiveIDs must error rather than silently
+// return a partial set (which would let live jobs be marked orphaned).
+func TestCollectLiveIDs_PaginationCapErrors(t *testing.T) {
+	sp := specByName(t, "transcribe")
+	full := make([]*asynq.TaskInfo, 500)
+	for i := range full {
+		full[i] = &asynq.TaskInfo{Type: sp.taskType, Payload: []byte(`{"fileId":"x"}`)}
+	}
+	list := func(_ string, _ ...asynq.ListOption) ([]*asynq.TaskInfo, error) { return full, nil }
+
+	err := collectLiveIDs(list, sp, map[string]struct{}{})
+	if err == nil {
+		t.Fatal("expected an error when pagination cap is hit, got nil")
+	}
+	if !strings.Contains(err.Error(), "liveness set incomplete") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// TestCollectLiveIDs_QueueNotFound: a never-seen queue is zero live tasks, not a
+// failure — collectLiveIDs swallows the wrapped ErrQueueNotFound.
+func TestCollectLiveIDs_QueueNotFound(t *testing.T) {
+	sp := specByName(t, "transcribe")
+	list := func(_ string, _ ...asynq.ListOption) ([]*asynq.TaskInfo, error) {
+		return nil, fmt.Errorf("asynq: %w", asynq.ErrQueueNotFound)
+	}
+	live := map[string]struct{}{}
+	if err := collectLiveIDs(list, sp, live); err != nil {
+		t.Fatalf("queue-not-found should be a nil error, got %v", err)
+	}
+	if len(live) != 0 {
+		t.Fatalf("live = %v, want empty", live)
+	}
+}
 
 func strPtr(s string) *string { return &s }
 func intPtr(i int) *int       { return &i }

--- a/backend/migrations/00023_jobreaper_stuck_job_indexes.sql
+++ b/backend/migrations/00023_jobreaper_stuck_job_indexes.sql
@@ -1,0 +1,57 @@
+-- +goose NO TRANSACTION
+--
+-- This migration builds its indexes CONCURRENTLY (mirrors 00021/00022), which
+-- cannot run inside a transaction. Every statement is idempotent (IF [NOT]
+-- EXISTS) so a re-run after a mid-migration failure is harmless.
+--
+-- These partial indexes back the job reaper's per-spec scan
+-- (internal/services/jobreaper). That loop runs every few minutes on every
+-- worker/all node and selects rows whose job status is still non-terminal:
+--
+--   SELECT id FROM <table>
+--   WHERE <status_col> IN ('queued','processing')
+--     AND trashed_at IS NULL
+--     AND updated_at < NOW() - grace
+--   ORDER BY updated_at ASC
+--   LIMIT n
+--
+-- Without an index this degrades into a sequential scan of files/moments as the
+-- tables grow. A partial index whose predicate matches the non-terminal status
+-- filter stays tiny (only in-flight rows are indexed — typically a handful — and
+-- a row drops out the moment it reaches a terminal state) and its updated_at key
+-- satisfies the ORDER BY ... LIMIT directly. One index per reaped status column.
+
+-- +goose Up
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS files_transcribe_reap_idx
+    ON files (updated_at)
+    WHERE transcribe_status IN ('queued', 'processing')
+      AND trashed_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS files_proxy_reap_idx
+    ON files (updated_at)
+    WHERE proxy_status IN ('queued', 'processing')
+      AND trashed_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS files_audio_detect_reap_idx
+    ON files (updated_at)
+    WHERE audio_detect_status IN ('queued', 'processing')
+      AND trashed_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS files_waveform_reap_idx
+    ON files (updated_at)
+    WHERE waveform_status IN ('queued', 'processing')
+      AND trashed_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS moments_export_reap_idx
+    ON moments (updated_at)
+    WHERE export_status IN ('queued', 'processing')
+      AND trashed_at IS NULL;
+
+-- +goose Down
+
+DROP INDEX CONCURRENTLY IF EXISTS moments_export_reap_idx;
+DROP INDEX CONCURRENTLY IF EXISTS files_waveform_reap_idx;
+DROP INDEX CONCURRENTLY IF EXISTS files_audio_detect_reap_idx;
+DROP INDEX CONCURRENTLY IF EXISTS files_proxy_reap_idx;
+DROP INDEX CONCURRENTLY IF EXISTS files_transcribe_reap_idx;

--- a/helm/alcoves/values.yaml
+++ b/helm/alcoves/values.yaml
@@ -72,16 +72,22 @@ backend:
   worker:
     enabled: true
     replicaCount: 1
-    # Whisper medium needs ~2.5GB RAM at runtime (f16 weights + KV cache).
-    # Combined with a concurrent ffmpeg transcode and ONNX detect job, the
-    # worker can spike past 4GB. Request 4Gi so the scheduler reserves
-    # enough; cap at 10Gi for long videos with multiple in-flight tasks.
-    # No CPU limit — whisper.cpp + ffmpeg can soak whatever the node has,
-    # and CFS throttling at a hard limit hurts more than it helps for these
-    # bursty, latency-sensitive jobs. Request 2 cores for scheduling.
+    # Memory is sized for the worker's asynq concurrency (8 in-flight tasks per
+    # pod). Each heavy job is RAM-hungry: whisper medium ~2.5GB (f16 weights +
+    # KV cache), whisper large ~4-5GB, plus concurrent ffmpeg transcodes and
+    # ONNX detect jobs each holding decoded frames/tensors. Several of these
+    # running at once can easily clear 10GB, which is what was OOM-killing the
+    # pool and orphaning jobs mid-flight. Be generous: request 8Gi so the
+    # scheduler reserves a realistic working set, and cap at 24Gi to absorb a
+    # worst-case burst of multiple large whisper + transcode jobs without the
+    # kernel reaping the pod. Tune down per-deployment if your media is light
+    # or you lower worker concurrency.
+    # No CPU limit — whisper.cpp + ffmpeg can soak whatever the node has, and
+    # CFS throttling at a hard limit hurts more than it helps for these bursty,
+    # latency-sensitive jobs. Request 2 cores for scheduling.
     resources:
-      requests: { cpu: 2, memory: 4Gi }
-      limits:   { memory: 10Gi }
+      requests: { cpu: 2, memory: 8Gi }
+      limits:   { memory: 24Gi }
     podAnnotations: {}
     nodeSelector: {}
     affinity: {}

--- a/helm/alcoves/values.yaml
+++ b/helm/alcoves/values.yaml
@@ -71,23 +71,27 @@ backend:
 # =============================================================================
   worker:
     enabled: true
-    replicaCount: 1
-    # Memory is sized for the worker's asynq concurrency (8 in-flight tasks per
-    # pod). Each heavy job is RAM-hungry: whisper medium ~2.5GB (f16 weights +
-    # KV cache), whisper large ~4-5GB, plus concurrent ffmpeg transcodes and
-    # ONNX detect jobs each holding decoded frames/tensors. Several of these
-    # running at once can easily clear 10GB, which is what was OOM-killing the
-    # pool and orphaning jobs mid-flight. Be generous: request 8Gi so the
-    # scheduler reserves a realistic working set, and cap at 24Gi to absorb a
-    # worst-case burst of multiple large whisper + transcode jobs without the
-    # kernel reaping the pod. Tune down per-deployment if your media is light
-    # or you lower worker concurrency.
+    # Scale throughput OUT, not up: each pod runs asynq at concurrency 2 (see
+    # cmd/server/main.go), so to process more jobs in parallel add replicas
+    # rather than raising per-pod concurrency. More pods spread peak memory
+    # across nodes and fail independently — a single fat, high-concurrency pod
+    # concentrates OOM risk, which is exactly what was orphaning jobs. Default to
+    # 3 workers so a couple of heavy long-runners (whisper/transcode) don't block
+    # the rest of the queue.
+    replicaCount: 3
+    # Memory is sized for asynq concurrency 2 (two in-flight heavy jobs per pod).
+    # Each is RAM-hungry: whisper medium ~2.5GB (f16 weights + KV cache), whisper
+    # large ~4-5GB, plus ffmpeg transcodes and ONNX detect jobs holding decoded
+    # frames/tensors. Two large jobs at once can approach ~10GB, so request 4Gi
+    # for a realistic working set and cap at 12Gi to absorb a worst-case pair
+    # without the kernel reaping the pod. Raise these in lockstep if you raise
+    # per-pod concurrency.
     # No CPU limit — whisper.cpp + ffmpeg can soak whatever the node has, and
     # CFS throttling at a hard limit hurts more than it helps for these bursty,
     # latency-sensitive jobs. Request 2 cores for scheduling.
     resources:
-      requests: { cpu: 2, memory: 8Gi }
-      limits:   { memory: 24Gi }
+      requests: { cpu: 2, memory: 4Gi }
+      limits:   { memory: 12Gi }
     podAnnotations: {}
     nodeSelector: {}
     affinity: {}

--- a/website/src/content/docs/features/admin-and-job-queue.md
+++ b/website/src/content/docs/features/admin-and-job-queue.md
@@ -167,17 +167,52 @@ higher-priority queues while they have a backlog.
 
 ### Periodic maintenance jobs
 
-Two background loops run on `worker`/`all` nodes without any user action:
+Three background loops run on `worker`/`all` nodes without any user action:
 
 - **Metadata backfill** enqueues EXIF/media-metadata extraction for media files
   that have never been extracted.
 - **Image-proxy variant pre-warm** (hourly) generates every cache variant for
   each image so the first view is instant rather than waiting on a transform.
   Disable it with `ALCOVES_IMAGE_PROXY_PREWARM_ENABLED=false`.
+- **Job reaper** (every 5 minutes) recovers jobs that crashed mid-flight — see
+  below.
 
-Both give up on a file after **3 failed attempts**, so a permanently-broken
-file (e.g. a corrupted image) is never re-queued forever — it shows up as a
-failed job at most three times and is then dropped from the backfill scan.
+The first two give up on a file after **3 failed attempts**, so a
+permanently-broken file (e.g. a corrupted image) is never re-queued forever — it
+shows up as a failed job at most three times and is then dropped from the
+backfill scan.
+
+### Stuck-job recovery (the reaper)
+
+A worker can die part-way through a job — an out-of-memory kill, a pod eviction,
+or Asynq exhausting its retries and archiving the task. When that happens the
+queue no longer holds the task, but the database row still advertises the job as
+`processing` (or `queued`): a thumbnail or transcript spinner that never
+resolves. Left alone, that row stays dirty forever.
+
+The **job reaper** reconciles the database against the queue every five minutes.
+A job is treated as orphaned only when **both** are true:
+
+- its status column is non-terminal (`queued` / `processing`), **and**
+- the Asynq inspector reports **no live task** (active, pending, scheduled, or
+  retrying) for that file or moment.
+
+Using the queue itself as the source of truth is what keeps this safe for
+**long-running jobs**: a multi-hour whisper transcribe is "active" in the queue
+the entire time it runs, so the reaper never touches it — there is no wall-clock
+timeout that could kill a healthy job. Only rows whose task has genuinely
+vanished are recovered.
+
+Recovery marks the row **failed** (clearing its progress bar and recording an
+"orphaned" reason) rather than re-running it. A failed job is a clean terminal
+state: the spinner stops, the breakage is visible in the dashboard, and it can
+be retried manually. The reaper deliberately does not auto-re-enqueue, because
+the usual cause of orphaning is an input that crashes its worker — blindly
+retrying it would just crash the worker pool again in a loop.
+
+It covers transcription, video proxy, audio-event detection, waveform
+generation, and moment export. (Metadata and image pre-warm aren't reaped here —
+their own backfill loops above already recover stuck rows.)
 
 ### Reading the dashboard
 


### PR DESCRIPTION
## Problem

A worker can die mid-job — OOM kill, pod eviction, or Asynq exhausting its retries and **archiving** the task — between marking a row `processing` and reaching a terminal state. The queue then holds no task, but the DB row still advertises the job as running **forever**: a transcript/thumbnail spinner that never resolves.

This is live right now on the cluster: **150+ files wedged in `transcribe_status='processing'`** (oldest ~6h) behind a crash-looping worker pool. Age distribution made the cause obvious — a tight cluster of genuinely-running jobs (<3 min) and a long tail stuck 1.6–6h:

| age | count |
|---|---|
| <10 min | 3 (live) |
| 10–30 min | 18 |
| >60 min | **155 (orphaned)** |

## Approach

A **job reaper**: a 5-minute background loop (worker/`all` nodes) that reconciles each job's status column against the queue. A row is orphaned only when **both**:

- its status column is non-terminal (`queued`/`processing`), **and**
- the Asynq inspector reports **no live task** (active/pending/scheduled/retry) for that file/moment.

Using the queue as the liveness oracle is what makes this **safe for long-runners**: a multi-hour whisper transcribe is `active` in Redis the whole time, so there is no wall-clock timeout that could kill a healthy job — only genuinely vanished tasks are reaped.

Recovery marks the row **`failed`** (clears progress, records an "orphaned" reason) rather than re-enqueuing. The usual cause of orphaning is a poison-pill input that crashes its worker; blind retry would just re-crash the pool. `failed` is a clean terminal state — spinner stops, breakage is visible in the admin dashboard, and it stays manually retryable.

Covers transcribe, video proxy, audio detection, waveform, and moment export. Metadata and image pre-warm are intentionally excluded — their own bounded-retry backfill loops already recover stuck rows.

## Design notes

- `files.updated_at` alone is a noisy heartbeat (any column write bumps it), so it is used only as a 15-min grace debounce against the enqueue race — the queue is the authority on liveness.
- A 15-min grace window guards the gap between a worker writing the status row and the task becoming visible to the inspector.
- `markFailed` carries a `status IN ('queued','processing')` guard, so a row that completed between scan and update is left untouched (TOCTOU-safe). An erroneously-reaped live job self-corrects: its next progress write overwrites the `failed` flicker.
- Task-type wire strings are mirrored locally to keep the reaper decoupled from the heavy worker packages; a test locks them to the canonical constants so a rename can't silently break the liveness match.

## Validation

- New package `internal/services/jobreaper` with unit tests (orphan selection, payload parsing) + DB-backed tests (candidate scan, status-guarded mark-failed, files + moments).
- Dry-ran the candidate query against the live cluster DB (read-only): correctly partitions stale candidates from the fresh in-grace rows.
- Full backend suite green: `go test ./... -p 1` → exit 0, 31 packages ok.
- Updated the admin/job-queue feature doc with a "Stuck-job recovery (the reaper)" section.