### PR TITLE
fix(jobreaper): set User/Library ID via embedded BaseModel in tests

### DIFF
--- a/backend/internal/services/jobreaper/reaper_test.go
+++ b/backend/internal/services/jobreaper/reaper_test.go
@@ -145,9 +145,9 @@ func setupReaperTestDB(t *testing.T) (*gorm.DB, uuid.UUID) {
 	db.Exec("DELETE FROM users")
 
 	userID := uuid.New()
-	db.Create(&models.User{ID: userID, Email: userID.String()[:8] + "@t.com", DisplayName: "U", Role: "owner"})
+	db.Create(&models.User{BaseModel: models.BaseModel{ID: userID}, Email: userID.String()[:8] + "@t.com", DisplayName: "U", Role: "owner"})
 	libID := uuid.New()
-	db.Create(&models.Library{ID: libID, Name: "L", OwnerID: userID})
+	db.Create(&models.Library{BaseModel: models.BaseModel{ID: libID}, Name: "L", OwnerID: userID})
 	return db, libID
 }
 
@@ -265,7 +265,7 @@ func TestCandidatesAndMarkFailed_Moments(t *testing.T) {
 		t.Fatal(err)
 	}
 	userID := uuid.New()
-	db.Create(&models.User{ID: userID, Email: userID.String()[:8] + "@t.com", DisplayName: "C", Role: "viewer"})
+	db.Create(&models.User{BaseModel: models.BaseModel{ID: userID}, Email: userID.String()[:8] + "@t.com", DisplayName: "C", Role: "viewer"})
 
 	m := models.Moment{
 		FileID: file.ID, LibraryID: libID, CreatedByID: userID,


### PR DESCRIPTION
## Why

PRs #574 (job reaper) and #575 (media-job detangle) were each green in isolation but **broke `main` when combined**:

- #575 moved the `ID` primary key into an embedded `BaseModel`.
- #574's `reaper_test.go` constructs `models.User{ID: ...}` / `models.Library{ID: ...}`.

`ID` is now a *promoted* field, not a direct one, so those struct literals no longer compile — the `backend-test` vet step fails for **every** open PR rebased onto current main:

```
vet: internal/services/jobreaper/reaper_test.go:148:25: unknown field ID in struct literal of type models.User
```

## Fix

Set the PK via `BaseModel: models.BaseModel{ID: ...}` in the three affected struct literals. Test-only change; no production code touched.

`go test ./internal/services/jobreaper/...` and `go vet ./...` are green.