### PR TITLE
fix(ci): build cached whisper.cpp with portable x86-64-v3 baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/whisper-dist
-          key: whisper-${{ runner.os }}-${{ env.WHISPER_VERSION }}
+          # The -x86-64-v3 suffix invalidates the earlier cache that was built
+          # with native CPU detection (it baked in the builder runner's AVX-512
+          # and SIGILL'd — "illegal instruction" — when restored onto a runner
+          # without it). Bump this suffix if the build flags below change again.
+          key: whisper-${{ runner.os }}-${{ env.WHISPER_VERSION }}-x86-64-v3
 
       - name: Build whisper.cpp (whisper-cli)
         if: steps.whisper-cache.outputs.cache-hit != 'true'
@@ -107,7 +111,17 @@ jobs:
           # transcription real-data test runs against the real binary. Models are
           # downloaded at test time. Outputs go to the cached /tmp/whisper-dist.
           git clone --depth 1 --branch "${WHISPER_VERSION}" https://github.com/ggerganov/whisper.cpp.git /tmp/whisper.cpp
-          cmake -S /tmp/whisper.cpp -B /tmp/whisper.cpp/build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
+          # Portable x86-64-v3 baseline (AVX/AVX2/FMA/F16C on, AVX-512 OFF, no
+          # -march=native) — mirrors the prod Dockerfile. The artifact is cached
+          # and restored onto arbitrary GitHub runners, so it must NOT bake in
+          # the builder's CPU features or whisper-cli SIGILLs on narrower runners.
+          cmake -S /tmp/whisper.cpp -B /tmp/whisper.cpp/build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
+            -DWHISPER_NATIVE=OFF -DGGML_NATIVE=OFF \
+            -DWHISPER_AVX=ON -DWHISPER_AVX2=ON -DWHISPER_FMA=ON -DWHISPER_F16C=ON \
+            -DWHISPER_AVX512=OFF -DWHISPER_AVX512_VBMI=OFF -DWHISPER_AVX512_VNNI=OFF \
+            -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON \
+            -DGGML_AVX512=OFF -DGGML_AVX512_VBMI=OFF -DGGML_AVX512_VNNI=OFF \
+            -DCMAKE_C_FLAGS=-march=x86-64-v3 -DCMAKE_CXX_FLAGS=-march=x86-64-v3
           cmake --build /tmp/whisper.cpp/build -j --config Release
           mkdir -p /tmp/whisper-dist/bin /tmp/whisper-dist/lib
           cp /tmp/whisper.cpp/build/bin/whisper-cli /tmp/whisper-dist/bin/


### PR DESCRIPTION
## Bug

#597 added a cache for the whisper.cpp build but compiled it with cmake's **default native CPU detection** — so `whisper-cli` baked in the *builder* runner's instruction set (including AVX-512). On #597's own CI the build+test ran on the same runner, so it passed. But on a later **cache HIT** the artifact is restored onto a *different* GitHub runner, and:

```
realinference_test.go:76: transcribe run: signal: illegal instruction (core dumped)
--- FAIL: TestRealTranscription_SpeechFixture
```

i.e. `backend-test` on `main` is now **intermittently red** (whenever the cache-builder runner had wider instructions than the test runner). Caught it on PR #598 (a config-only PR — innocent victim).

## Fix

Build whisper.cpp with a **portable x86-64-v3 baseline** (AVX/AVX2/FMA/F16C on, **AVX-512 OFF**, `*_NATIVE=OFF`, `-march=x86-64-v3`) — the *exact* flags the prod `Dockerfile` already uses for the same reason. The cached binary now runs on any modern x86-64 runner. Cache key suffix bumped to `-x86-64-v3` to evict the bad native-built artifact.

This restores the pre-#597 guarantee (which held implicitly because whisper was rebuilt per-run on the same runner) while keeping the caching speedup.

## Note

A cold first run rebuilds on its own runner (always passes); the portability guarantee is structural (matches the proven Dockerfile baseline) and takes effect on subsequent warm-cache runs across the heterogeneous runner pool.