### PR TITLE
ci(backend): split the heavy handlers package's tests across shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,12 +155,22 @@ jobs:
         # (The shared queue, not just the DB, is why -p 1 is still load-bearing:
         # only filehash isolates onto its own Redis DB; the rest use DB 0.)
         #
-        # Packages are partitioned by `go list` order (round-robin) so each runs
-        # in exactly one shard and the three shards together cover every package.
+        # internal/handlers (~494 tests, ~130s — by far the heaviest package) is
+        # split BY TEST NAME across shards via -run so it no longer bottlenecks one
+        # shard; every other package is round-robined by `go list` order. -list
+        # reuses the same -race build cache as the run (handlers compiles once),
+        # and `bash -eo pipefail` makes a broken split fail loudly, never silently
+        # drop tests. Together the shards cover every package and every handlers test.
         run: |
-          PKGS=$(go list ./... | awk -v s=${{ matrix.shard }} 'NR % 3 == (s - 1)')
+          HANDLERS=github.com/alcoves/alcoves-backend/internal/handlers
+          PKGS=$(go list ./... | grep -vx "$HANDLERS" | awk -v s=${{ matrix.shard }} 'NR % 3 == (s - 1)')
           echo "shard ${{ matrix.shard }}/3 packages:"; echo "$PKGS"
           go test $PKGS -race -count=1 -p 1
+
+          HTESTS=$(go test "$HANDLERS" -race -list '.*' | grep -E '^(Test|Fuzz|Example)' \
+            | awk -v s=${{ matrix.shard }} 'NR % 3 == (s - 1)' | paste -sd'|' -)
+          echo "shard ${{ matrix.shard }}/3 handlers tests: $(printf '%s' "$HTESTS" | tr '|' '\n' | grep -c .)"
+          go test "$HANDLERS" -race -count=1 -p 1 -run "^(${HTESTS})$"
 
   unit-and-coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

After 3-way package sharding (#597), `internal/handlers` is the bottleneck. Per-package timings: **handlers = 128.8s**, next heaviest is 30s, the rest sum to ~135s. A single package can't be split by package-sharding, so the handlers shard stayed ~6min (warm) while the others finished in ~2-3min.

## What

Split **handlers' ~494 top-level tests across the 3 shards by name** via `-run`, round-robining every other package as before:

- `-list` reuses the same `-race` build cache as the run, so handlers compiles **once** per shard.
- `bash -eo pipefail` (GitHub default) makes a broken split **fail loudly**, never silently drop tests — CI-gated, not a flakiness risk.
- Subtests run with their parent (top-level `-run` anchoring).
- Verified locally: partition is disjoint + complete (164/165/165 = 494 handlers tests; 12/13/12 other packages).
- Safety model from #597 unchanged: each shard has its own postgres+dragonfly; `-p 1` within a shard.

## Expected

Slowest `backend-test` shard **~6min -> ~4min** (handlers' ~130s becomes ~45s/shard). Combined with #597/#599, backend-test goes from the original ~9m27s toward ~4min.

## Next lever (follow-up)

Caching the 51s libvips/ffmpeg apt install would trim shard setup further (~135s -> ~95s).
