### PR TITLE
ci(backend): widen backend-test to 5 shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5]
     defaults:
       run:
         working-directory: backend
@@ -144,8 +144,8 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - name: Test (shard ${{ matrix.shard }}/3)
-        # The suite is sharded across 3 matrix jobs to parallelise it. Each shard
+      - name: Test (shard ${{ matrix.shard }}/5)
+        # The suite is sharded across 5 matrix jobs to parallelise it. Each shard
         # gets its OWN postgres + dragonfly service containers, so the shared test
         # DB and the shared Asynq queue cannot be contended ACROSS shards.
         #
@@ -163,13 +163,13 @@ jobs:
         # drop tests. Together the shards cover every package and every handlers test.
         run: |
           HANDLERS=github.com/alcoves/alcoves-backend/internal/handlers
-          PKGS=$(go list ./... | grep -vx "$HANDLERS" | awk -v s=${{ matrix.shard }} 'NR % 3 == (s - 1)')
-          echo "shard ${{ matrix.shard }}/3 packages:"; echo "$PKGS"
+          PKGS=$(go list ./... | grep -vx "$HANDLERS" | awk -v s=${{ matrix.shard }} 'NR % 5 == (s - 1)')
+          echo "shard ${{ matrix.shard }}/5 packages:"; echo "$PKGS"
           go test $PKGS -race -count=1 -p 1
 
           HTESTS=$(go test "$HANDLERS" -race -list '.*' | grep -E '^(Test|Fuzz|Example)' \
-            | awk -v s=${{ matrix.shard }} 'NR % 3 == (s - 1)' | paste -sd'|' -)
-          echo "shard ${{ matrix.shard }}/3 handlers tests: $(printf '%s' "$HTESTS" | tr '|' '\n' | grep -c .)"
+            | awk -v s=${{ matrix.shard }} 'NR % 5 == (s - 1)' | paste -sd'|' -)
+          echo "shard ${{ matrix.shard }}/5 handlers tests: $(printf '%s' "$HTESTS" | tr '|' '\n' | grep -c .)"
           go test "$HANDLERS" -race -count=1 -p 1 -run "^(${HTESTS})$"
 
   unit-and-coverage:


### PR DESCRIPTION
## Why

After splitting the heavy `internal/handlers` package's tests across shards (#600), the slowest `backend-test` shard was ~294s (warm) — bounded by the per-shard test grouping (handlers-third ~26s + whichever heavy service packages landed together) plus ~136s fixed setup.

## What

Widen the matrix 3 -> 5 shards. Both the handlers test-name split and the non-handlers round-robin now divide 5 ways, spreading the heavy service packages (objectdetection 30s, facedetection 17s, ...) and the handlers thirds further so the slowest shard drops toward the setup floor.

- Partition verified disjoint + complete: handlers 98/99/99/99/99 = 494; non-handlers 7/8/8/7/7.
- Same safety model: each shard has its own postgres+dragonfly; `-p 1` within a shard; portable whisper cache (#599).
- Public repo → the extra matrix runner-minutes are free.

## Expected

Slowest shard ~294s -> ~230s. The remaining floor is per-shard native-dep setup (~136s: postgres/dragonfly containers + the 51s libvips/ffmpeg apt). Cutting that further needs either apt caching or a prebuilt CI base image with the deps baked in (a larger change).
