### PR TITLE
ci(backend): cache the libvips/ffmpeg apt download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,27 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
 
+      # Cache the downloaded .debs (the slow part of the apt install ~50s) so
+      # warm runs skip the download and only unpack/configure. Versions are in
+      # the key implicitly via the monthly-ish runner image; a package bump just
+      # misses for that one deb and re-downloads it (self-healing).
+      - name: Cache apt archives (libvips + ffmpeg)
+        uses: actions/cache@v4
+        with:
+          path: ~/.apt-archives
+          key: apt-${{ runner.os }}-libvips-ffmpeg-v1
+
       - name: Install libvips + ffmpeg
         run: |
+          mkdir -p ~/.apt-archives
           sudo apt-get update
           # ffmpeg powers the audio extraction in the waveform, audio-event
-          # detection, and transcription real-data tests.
-          sudo apt-get install -y libvips-dev libheif-plugin-aomenc libheif-plugin-x265 ffmpeg
+          # detection, and transcription real-data tests. -o Dir::Cache::Archives
+          # points apt at the cached .deb dir so unchanged packages aren't re-downloaded.
+          sudo apt-get -o Dir::Cache::Archives="$HOME/.apt-archives" install -y \
+            libvips-dev libheif-plugin-aomenc libheif-plugin-x265 ffmpeg
+          # make root-written debs readable so actions/cache can save them
+          sudo chmod -R a+rX ~/.apt-archives
 
       - name: Install ONNX Runtime
         run: |


### PR DESCRIPTION
## Why

After 5-way sharding (#601) backend-test sits at ~3m35s, bounded by per-shard setup. The `libvips-dev` + heif plugins + `ffmpeg` apt install is ~50s of that, almost all download.

## What

Cache the downloaded `.deb` archives (first-party `actions/cache` + `apt-get -o Dir::Cache::Archives`), so warm runs skip the download and only unpack/configure (~15s).

- Package list **unchanged** (no `--no-install-recommends`) → installed deps are identical.
- Self-healing: a package version bump just misses the cache for that one deb and re-downloads it.
- Nothing else changes (service containers + test run untouched).

## Expected

Per-shard setup ~50s -> ~15s on warm runs; slowest `backend-test` shard ~215s -> ~180s (~3min). The remaining floor is the postgres/dragonfly service-container init (~66s), which is unavoidable without baking a base image (and even then the service containers persist).
