### PR TITLE
fix(client): stop the settings-page effect loop that broke the mobile sidebar

### DIFF
--- a/client/src/routes/(app)/libraries/[id]/settings/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/settings/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { page } from '$app/state';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { Switch } from '@skeletonlabs/skeleton-svelte';
@@ -57,9 +57,13 @@
 
 	// Keep the role drafts reconciled with the members list whenever it changes.
 	$effect(() => {
-		// Touch `members.libraryMembers` so the effect re-runs on member changes.
+		// Re-run only when the member list changes. syncDrafts() writes
+		// `memberRoleDrafts` (which it also reads, to preserve in-flight edits), so
+		// it MUST run untracked — otherwise the effect tracks that write and
+		// re-triggers itself forever (effect_update_depth_exceeded), which silently
+		// breaks reactivity for the whole page (the mobile sidebar wouldn't open).
 		void members.libraryMembers;
-		members.syncDrafts();
+		untrack(() => members.syncDrafts());
 	});
 
 	let newLinkMaxUses = $state('');

--- a/client/test/e2e/mobile-nav.e2e.ts
+++ b/client/test/e2e/mobile-nav.e2e.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+import { login } from './helpers/auth';
+
+/**
+ * Regression: a runaway `$effect` on the library settings page (it called
+ * `syncDrafts()`, which writes `memberRoleDrafts` — a value it also tracked)
+ * threw `effect_update_depth_exceeded`. That broke Svelte's reactivity scheduler
+ * for the whole page, so the mobile sidebar hamburger no longer opened the drawer
+ * (`sidebarOpen = true` never propagated to the controlled Dialog). Guard both the
+ * symptom (hamburger works) and the cause (no effect loop) on the settings page.
+ */
+test('mobile hamburger opens the sidebar drawer on the settings page', async ({ page }) => {
+	const pageErrors: string[] = [];
+	page.on('pageerror', (e) => pageErrors.push(e.message));
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await login(page);
+	await page.waitForURL(/\/libraries\/[^/?]+/, { timeout: 15_000 });
+	const id = page.url().match(/libraries\/([^/?]+)/)![1];
+
+	await page.goto(`/libraries/${id}/settings`);
+	await page.waitForFunction(() => window.__alcovesReady === true, undefined, { timeout: 20_000 });
+
+	await page.getByRole('button', { name: 'Open sidebar' }).click();
+	await expect(page.getByRole('navigation', { name: /Library sections/i }).first()).toBeVisible({
+		timeout: 5_000
+	});
+
+	expect(pageErrors.join('\n')).not.toContain('effect_update_depth_exceeded');
+});


### PR DESCRIPTION
## Problem

On the library **settings page**, tapping the mobile sidebar **hamburger did nothing** — the drawer wouldn't open.

## Root cause

The settings page ran `members.syncDrafts()` inside a `$effect`. `syncDrafts()` *reads* `memberRoleDrafts` (to preserve in-flight role edits) and *writes* a brand-new `memberRoleDrafts` object every call. Because the effect tracked that read, every write re-triggered the effect — an infinite loop that threw `effect_update_depth_exceeded`, which **broke Svelte's reactivity scheduler for the whole page**.

The hamburger's `onclick` did run and set `sidebarOpen = true`, but with reactivity dead the controlled `<Dialog open={sidebarOpen}>` never updated, so the drawer stayed closed. (Diagnosed via instrumented Playwright runs: the handler fired, but the `sidebarOpen` effect never re-ran and a `pageerror: .../e/effect_update_depth_exceeded` was present — only on settings, which has seeded members.)

Pre-existing bug, unrelated to the recent UI work; the sidebar was just collateral damage.

## Fix

Run `syncDrafts()` via `untrack()` so the effect depends only on the member list, not on the drafts it writes — which is also the intended semantics (re-sync when members change, not when a draft edit happens).

## Test

Adds `test/e2e/mobile-nav.e2e.ts`: on a 390px viewport, open the settings page, click the hamburger, assert the drawer nav becomes visible **and** that no `effect_update_depth_exceeded` page error occurred. Verified failing before / passing after.

- `typecheck` 0 errors · settings unit suite 48 passed · prettier + eslint clean · the new e2e passes against the seeded stack.