### PR TITLE
fix(client): de-duplicate the emoji in the library switcher rows

### DIFF
--- a/client/src/lib/components/LibrarySwitcher.svelte
+++ b/client/src/lib/components/LibrarySwitcher.svelte
@@ -36,10 +36,6 @@
 		(libraries ?? []).filter((l) => !l.isDefault).sort((a, b) => a.name.localeCompare(b.name))
 	);
 
-	function label(l: Library): string {
-		return l.emoji ? `${l.emoji}  ${l.name}` : l.name;
-	}
-
 	function select(id: string) {
 		open = false;
 		goto(`/libraries/${id}`);
@@ -82,7 +78,7 @@
 					{:else}
 						<AppIcon name={ICONS.library} class="size-4 shrink-0 opacity-60" />
 					{/if}
-					<span class="min-w-0 flex-1 truncate">{label(def)}</span>
+					<span class="min-w-0 flex-1 truncate">{def.name}</span>
 					{#if def.id === current?.id}
 						<AppIcon name={ICONS.check} class="size-4 shrink-0 text-primary-500" />
 					{/if}
@@ -104,7 +100,7 @@
 						{:else}
 							<AppIcon name={ICONS.folder} class="size-4 shrink-0 opacity-60" />
 						{/if}
-						<span class="min-w-0 flex-1 truncate">{label(l)}</span>
+						<span class="min-w-0 flex-1 truncate">{l.name}</span>
 						{#if l.id === current?.id}
 							<AppIcon name={ICONS.check} class="size-4 shrink-0 text-primary-500" />
 						{/if}

--- a/client/src/lib/components/LibrarySwitcher.svelte.test.ts
+++ b/client/src/lib/components/LibrarySwitcher.svelte.test.ts
@@ -155,4 +155,25 @@ describe('LibrarySwitcher', () => {
 		const trigger = screen.container.querySelector('button[aria-haspopup]') as HTMLElement;
 		expect(trigger.textContent).toContain('🏠');
 	});
+
+	it('shows each library emoji exactly once per dropdown row (not duplicated)', async () => {
+		const screen = render(LibrarySwitcher, {
+			props: {
+				libraries: [
+					lib({ id: 'def', name: 'Home', isDefault: true, emoji: '🏠' }),
+					lib({ id: 'lib-2', name: 'Projects', emoji: '🚀' })
+				],
+				currentLibraryId: 'def'
+			}
+		});
+		await open(screen);
+		// Dropdown rows are the buttons that aren't the popover trigger.
+		const rows = Array.from(screen.container.querySelectorAll('button')).filter(
+			(b) => !b.hasAttribute('aria-haspopup')
+		);
+		const homeRow = rows.find((b) => b.textContent?.includes('Home'));
+		const projRow = rows.find((b) => b.textContent?.includes('Projects'));
+		expect((homeRow?.textContent?.match(/🏠/g) ?? []).length).toBe(1);
+		expect((projRow?.textContent?.match(/🚀/g) ?? []).length).toBe(1);
+	});
 });


### PR DESCRIPTION
## Problem

Each row in the library-switcher dropdown showed the library **emoji twice**.

## Cause

A row rendered the emoji as a leading glyph span **and** again in its text — `label()` returned `${emoji}  ${name}`, so the row became `🏠` (span) + `🏠  Home` (label) = `🏠🏠  Home`.

## Fix

Render just `{l.name}` in the rows (the leading span already shows the emoji) and remove the now-unused `label()` helper. The trigger was unaffected (it already used `current.name`).

## Test

Adds a regression to `LibrarySwitcher.svelte.test.ts`: opens the dropdown with emoji'd libraries and asserts each row's emoji appears **exactly once** (fails on the old code with count 2).

- typecheck 0 errors · LibrarySwitcher suite **8 passed** · prettier + eslint clean.