### PR TITLE
feat(client): app-wide upload queue with virtualized progress panel

### DIFF
--- a/client/src/lib/components/UploadProgress.svelte
+++ b/client/src/lib/components/UploadProgress.svelte
@@ -1,110 +1,288 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import { ICONS } from '$lib/utils/icons';
 	import { formatFileSize } from '$lib/utils/mime-icons';
 	import { uploadQueue } from '$lib/state/upload-queue.svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
 
+	/**
+	 * App-wide upload progress panel. Mounted once in the authed layout so it stays
+	 * pinned to the bottom-right and keeps reporting while the user navigates the
+	 * SPA — it remains fully visible until the queue drains to empty.
+	 *
+	 * The per-file list is **virtualized**: with thousands of queued files only the
+	 * handful of rows in the viewport (plus a small overscan) are in the DOM, so the
+	 * panel stays smooth regardless of queue size. Every row is a fixed height
+	 * (`ROW_H`) so the windowing math is exact.
+	 */
+
+	/** Fixed row height in px — MUST match each row's rendered height (`h-14`). */
+	const ROW_H = 56;
+	/** Extra rows rendered above/below the viewport to avoid blank flashes on scroll. */
+	const OVERSCAN = 6;
+	/** Max viewport height of the scroll area in px (capped to 50dvh on short screens). */
+	const VIEWPORT_H = 320;
+
 	let expanded = $state(true);
+	let filter = $state<'all' | 'failed'>('all');
+	let scrollTop = $state(0);
+	let viewportH = $state(VIEWPORT_H);
+	let toggleBtn = $state<HTMLButtonElement>();
+
+	// When the error filter is active the source is the (small) errored subset,
+	// otherwise it's the full queue exposed as-is (no copy on the hot path).
+	const displayItems = $derived(
+		filter === 'failed' ? uploadQueue.queue.filter((f) => f.status === 'error') : uploadQueue.queue
+	);
+
+	const total = $derived(displayItems.length);
+	const visibleCount = $derived(Math.ceil(viewportH / ROW_H) + OVERSCAN * 2);
+	// Clamp the window start so it can never render an empty slice past the end when
+	// the list shrinks under the user (sweep/cancel) or the filter narrows it.
+	const maxStart = $derived(Math.max(0, total - visibleCount));
+	const startIndex = $derived(
+		Math.min(maxStart, Math.max(0, Math.floor(scrollTop / ROW_H) - OVERSCAN))
+	);
+	const endIndex = $derived(Math.min(total, startIndex + visibleCount));
+	const windowItems = $derived(displayItems.slice(startIndex, endIndex));
+	const topPad = $derived(startIndex * ROW_H);
+	const bottomPad = $derived(Math.max(0, (total - endIndex) * ROW_H));
+
+	const overallPercent = $derived(uploadQueue.overallProgress);
+
+	const headerTitle = $derived(
+		uploadQueue.hasInFlightUploads
+			? 'Uploading'
+			: uploadQueue.errorCount > 0
+				? 'Finished with errors'
+				: 'Upload complete'
+	);
+
+	function onScroll(event: Event) {
+		scrollTop = (event.currentTarget as HTMLElement).scrollTop;
+	}
+
+	function toggleExpanded() {
+		expanded = !expanded;
+		// The scroll container remounts on expand; reset so the windowing state matches.
+		scrollTop = 0;
+	}
+
+	function setFilter(next: 'all' | 'failed') {
+		filter = next;
+		scrollTop = 0;
+	}
+
+	// Run a queue action, then return focus to the always-present header toggle so it
+	// doesn't fall to <body> when the activated control (a row button) unmounts.
+	async function act(fn: () => void) {
+		fn();
+		await tick();
+		toggleBtn?.focus();
+	}
+
+	// Warn before the page is unloaded while uploads are still in flight — a reload
+	// or close would abort them. Returning a string triggers the browser's native
+	// confirmation dialog.
+	function onBeforeUnload(event: BeforeUnloadEvent) {
+		if (!uploadQueue.hasInFlightUploads) return;
+		event.preventDefault();
+		event.returnValue = '';
+		return '';
+	}
 </script>
+
+<svelte:window onbeforeunload={onBeforeUnload} />
 
 {#if uploadQueue.hasActiveUploads}
 	<div
-		class="fixed right-4 bottom-4 z-50 w-96 overflow-hidden rounded-xl border border-surface-300-700 bg-surface-50-950 shadow-xl"
+		class="fixed right-4 bottom-4 z-50 w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-surface-300-700 bg-surface-50-950 shadow-xl sm:w-96"
+		role="region"
+		aria-label="Upload progress"
 	>
+		<!-- Header / collapse toggle -->
 		<button
 			type="button"
-			class="flex w-full items-center justify-between bg-surface-100-900 px-4 py-2.5 text-left select-none"
-			onclick={() => (expanded = !expanded)}
+			bind:this={toggleBtn}
+			class="flex w-full items-center justify-between gap-2 bg-surface-100-900 px-4 py-2.5 text-left select-none"
+			onclick={toggleExpanded}
+			aria-expanded={expanded}
 		>
-			<span class="text-sm font-medium">
-				Uploading {uploadQueue.activeUploads.length}
-				{uploadQueue.activeUploads.length === 1 ? 'file' : 'files'}
+			<span class="flex min-w-0 flex-col">
+				<span class="truncate text-sm font-medium">{headerTitle}</span>
+				<span class="text-xs opacity-60">
+					{uploadQueue.completedCount} of {uploadQueue.submittedCount}
+					{#if uploadQueue.errorCount > 0}
+						· <span class="text-error-500">{uploadQueue.errorCount} failed</span>
+					{/if}
+				</span>
 			</span>
-			<div class="flex items-center gap-2">
+			<span class="flex shrink-0 items-center gap-2">
 				{#if uploadQueue.uploadSpeed > 0}
 					<span class="text-xs opacity-60">{formatFileSize(uploadQueue.uploadSpeed)}/s</span>
 				{/if}
 				<AppIcon name={expanded ? ICONS.chevronDown : ICONS.chevronUp} class="size-4 opacity-60" />
-			</div>
+			</span>
 		</button>
 
-		{#if expanded && uploadQueue.erroredUploads.length > 0}
-			<div class="flex items-center justify-between border-t border-surface-300-700 px-4 py-1.5">
-				<span class="text-xs text-error-500">{uploadQueue.erroredUploads.length} failed</span>
-				<div class="flex gap-1">
-					<button
-						type="button"
-						class="btn preset-tonal btn-sm"
-						onclick={() => uploadQueue.retryAll()}
-					>
-						Retry All
-					</button>
-					<button
-						type="button"
-						class="btn preset-tonal-error btn-sm"
-						onclick={() => uploadQueue.clearErrors()}
-					>
-						Clear
-					</button>
-				</div>
-			</div>
-		{/if}
+		<!-- Overall progress (by completed file count) -->
+		<div class="h-1 w-full bg-surface-200-800">
+			<div
+				class="h-full bg-primary-500 transition-[width] duration-200"
+				style:width="{overallPercent}%"
+			></div>
+		</div>
 
 		{#if expanded}
-			<div class="max-h-64 space-y-1 overflow-y-auto px-2 py-2">
-				{#each uploadQueue.activeUploads as item (item.id)}
-					<div class="rounded-lg bg-surface-100-900/60 px-2 py-2">
-						<div class="mb-1 flex items-center justify-between">
-							<span class="mr-2 flex-1 truncate text-sm">{item.file.name}</span>
-							<span class="text-xs whitespace-nowrap opacity-60">{item.libraryName}</span>
-						</div>
-
-						{#if item.status === 'uploading'}
-							<div class="flex items-center gap-2">
-								<div
-									class="h-1.5 flex-1 overflow-hidden rounded-full bg-surface-300-700"
-									role="progressbar"
-									aria-valuenow={item.progress}
-									aria-valuemin={0}
-									aria-valuemax={100}
-								>
-									<div
-										class="h-full rounded-full bg-primary-500 transition-[width] duration-150"
-										style:width="{item.progress}%"
-									></div>
-								</div>
-								<span class="w-8 text-right text-xs opacity-60">{item.progress}%</span>
-							</div>
-						{:else if item.status === 'error'}
-							<div class="flex items-center justify-between">
-								<span class="text-xs text-error-500">{item.error}</span>
-								<div class="flex gap-1">
-									<button
-										type="button"
-										class="btn preset-tonal btn-sm"
-										onclick={() => uploadQueue.retryFile(item.id)}
-									>
-										Retry
-									</button>
-									<button
-										type="button"
-										class="btn preset-tonal-error btn-sm"
-										onclick={() => uploadQueue.removeFile(item.id)}
-									>
-										Remove
-									</button>
-								</div>
-							</div>
-						{:else if item.status === 'done'}
-							<div class="flex items-center gap-1">
-								<AppIcon name={ICONS.check} class="size-4 text-success-500" />
-								<span class="text-xs text-success-500">Complete</span>
-							</div>
-						{:else}
-							<div class="text-xs opacity-60">Waiting...</div>
+			{#if uploadQueue.hasInFlightUploads || uploadQueue.errorCount > 0}
+				<div
+					class="flex items-center justify-between gap-2 border-t border-surface-300-700 px-4 py-1.5"
+				>
+					<div class="flex gap-1">
+						{#if uploadQueue.errorCount > 0}
+							<button
+								type="button"
+								class="btn btn-sm {filter === 'all'
+									? 'preset-filled-surface-200-800'
+									: 'preset-tonal'}"
+								onclick={() => setFilter('all')}
+							>
+								All
+							</button>
+							<button
+								type="button"
+								class="btn btn-sm {filter === 'failed'
+									? 'preset-filled-error-500'
+									: 'preset-tonal-error'}"
+								onclick={() => setFilter('failed')}
+							>
+								{uploadQueue.errorCount} failed
+							</button>
 						{/if}
 					</div>
+					<div class="flex gap-1">
+						{#if uploadQueue.hasInFlightUploads}
+							<button
+								type="button"
+								class="btn preset-tonal btn-sm"
+								onclick={() => act(() => uploadQueue.cancelAll())}
+							>
+								Cancel all
+							</button>
+						{/if}
+						{#if uploadQueue.errorCount > 0}
+							<button
+								type="button"
+								class="btn preset-tonal btn-sm"
+								onclick={() => act(() => uploadQueue.retryAll())}
+							>
+								Retry all
+							</button>
+							<button
+								type="button"
+								class="btn preset-tonal-error btn-sm"
+								onclick={() => act(() => uploadQueue.clearErrors())}
+							>
+								Clear
+							</button>
+						{/if}
+					</div>
+				</div>
+			{/if}
+
+			<!-- Virtualized scroll area -->
+			<div
+				class="overflow-y-auto"
+				style:max-height="min({VIEWPORT_H}px, 50dvh)"
+				onscroll={onScroll}
+				bind:clientHeight={viewportH}
+			>
+				<div style:height="{topPad}px"></div>
+				{#each windowItems as item (item.id)}
+					<div
+						class="flex h-14 items-center gap-2 border-b border-surface-200-800/60 px-3"
+						data-upload-row
+					>
+						<div class="flex min-w-0 flex-1 flex-col justify-center gap-1">
+							<div class="flex items-center justify-between gap-2">
+								<span class="min-w-0 flex-1 truncate text-sm" title={item.file.name}
+									>{item.file.name}</span
+								>
+								<span class="shrink-0 text-xs whitespace-nowrap opacity-50">{item.libraryName}</span
+								>
+							</div>
+
+							{#if item.status === 'uploading'}
+								<div class="flex items-center gap-2">
+									<div
+										class="h-1.5 flex-1 overflow-hidden rounded-full bg-surface-300-700"
+										role="progressbar"
+										aria-valuenow={item.progress}
+										aria-valuemin={0}
+										aria-valuemax={100}
+									>
+										<div
+											class="h-full rounded-full bg-primary-500 transition-[width] duration-150"
+											style:width="{item.progress}%"
+										></div>
+									</div>
+									<span class="w-9 text-right text-xs opacity-60">{item.progress}%</span>
+								</div>
+							{:else if item.status === 'error'}
+								<span class="flex items-center gap-1 text-xs text-error-500">
+									<AppIcon name={ICONS.warning} class="size-3.5 shrink-0" />
+									<span class="truncate" title={item.error}>{item.error ?? 'Upload failed'}</span>
+								</span>
+							{:else if item.status === 'done'}
+								<span class="flex items-center gap-1 text-xs text-success-500">
+									<AppIcon name={ICONS.check} class="size-3.5 shrink-0" />
+									{#if item.duplicateCount && item.duplicateCount > 0}
+										Done · duplicate
+									{:else}
+										Done
+									{/if}
+								</span>
+							{:else}
+								<span class="text-xs opacity-50">Queued</span>
+							{/if}
+						</div>
+
+						<!-- Per-row actions -->
+						<div class="flex shrink-0 items-center gap-1">
+							{#if item.status === 'error'}
+								<button
+									type="button"
+									class="btn-icon btn-icon-sm preset-tonal"
+									aria-label="Retry upload"
+									title="Retry"
+									onclick={() => act(() => uploadQueue.retryFile(item.id))}
+								>
+									<AppIcon name={ICONS.retry} class="size-3.5" />
+								</button>
+								<button
+									type="button"
+									class="btn-icon btn-icon-sm preset-tonal-error"
+									aria-label="Remove upload"
+									title="Remove"
+									onclick={() => act(() => uploadQueue.removeFile(item.id))}
+								>
+									<AppIcon name={ICONS.trash} class="size-3.5" />
+								</button>
+							{:else if item.status === 'pending' || item.status === 'uploading'}
+								<button
+									type="button"
+									class="btn-icon btn-icon-sm preset-tonal"
+									aria-label="Cancel upload"
+									title="Cancel"
+									onclick={() => act(() => uploadQueue.cancelFile(item.id))}
+								>
+									<AppIcon name={ICONS.close} class="size-3.5" />
+								</button>
+							{/if}
+						</div>
+					</div>
 				{/each}
+				<div style:height="{bottomPad}px"></div>
 			</div>
 		{/if}
 	</div>

--- a/client/src/lib/components/UploadProgress.svelte.test.ts
+++ b/client/src/lib/components/UploadProgress.svelte.test.ts
@@ -9,45 +9,83 @@ type UploadItem = {
 	status: 'pending' | 'uploading' | 'error' | 'done';
 	progress: number;
 	error?: string;
+	duplicateCount?: number;
 };
 
 // Mutable fixture backing the mocked global store. Getters mirror the real
-// `uploadQueue` singleton so the component sees a fresh derived view per render.
+// `uploadQueue` singleton (O(1) counters, monotonic session totals, and the raw
+// `queue` the panel virtualizes).
 const fixture = {
-	items: [] as UploadItem[],
+	queue: [] as UploadItem[],
 	uploadSpeed: 0,
+	submitted: 0,
+	completed: 0,
 	retryFile: vi.fn(),
 	removeFile: vi.fn(),
+	cancelFile: vi.fn(),
+	cancelAll: vi.fn(),
 	retryAll: vi.fn(),
 	clearErrors: vi.fn()
 };
 
+const countBy = (s: string) => fixture.queue.filter((u) => u.status === s).length;
+
 vi.mock('$lib/state/upload-queue.svelte', () => ({
 	uploadQueue: {
-		get activeUploads() {
-			return fixture.items;
+		get queue() {
+			return fixture.queue;
+		},
+		get totalCount() {
+			return fixture.queue.length;
+		},
+		get pendingCount() {
+			return countBy('pending');
+		},
+		get uploadingCount() {
+			return countBy('uploading');
+		},
+		get errorCount() {
+			return countBy('error');
+		},
+		get doneCount() {
+			return countBy('done');
+		},
+		get submittedCount() {
+			return fixture.submitted;
+		},
+		get completedCount() {
+			return fixture.completed;
+		},
+		get overallProgress() {
+			return fixture.submitted > 0 ? Math.round((fixture.completed / fixture.submitted) * 100) : 0;
 		},
 		get hasActiveUploads() {
-			return fixture.items.length > 0;
+			return fixture.queue.length > 0;
 		},
-		get erroredUploads() {
-			return fixture.items.filter((u) => u.status === 'error');
+		get hasInFlightUploads() {
+			return countBy('pending') + countBy('uploading') > 0;
 		},
 		get uploadSpeed() {
 			return fixture.uploadSpeed;
 		},
 		retryFile: (id: string) => fixture.retryFile(id),
 		removeFile: (id: string) => fixture.removeFile(id),
+		cancelFile: (id: string) => fixture.cancelFile(id),
+		cancelAll: () => fixture.cancelAll(),
 		retryAll: () => fixture.retryAll(),
 		clearErrors: () => fixture.clearErrors()
 	}
 }));
 
 beforeEach(() => {
-	fixture.items = [];
+	fixture.queue = [];
 	fixture.uploadSpeed = 0;
+	fixture.submitted = 0;
+	fixture.completed = 0;
 	fixture.retryFile.mockReset();
 	fixture.removeFile.mockReset();
+	fixture.cancelFile.mockReset();
+	fixture.cancelAll.mockReset();
 	fixture.retryAll.mockReset();
 	fixture.clearErrors.mockReset();
 });
@@ -60,14 +98,24 @@ function buttonByText(screen: ReturnType<typeof render>, text: string): HTMLButt
 	return btn!;
 }
 
+function buttonByLabel(screen: ReturnType<typeof render>, label: string): HTMLButtonElement {
+	const btn = screen.container.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+	expect(btn, `button [aria-label="${label}"]`).toBeTruthy();
+	return btn!;
+}
+
+function rows(screen: ReturnType<typeof render>): HTMLElement[] {
+	return Array.from(screen.container.querySelectorAll<HTMLElement>('[data-upload-row]'));
+}
+
 describe('UploadProgress', () => {
 	it('renders nothing when there are no active uploads', () => {
 		const screen = render(UploadProgress);
-		expect(screen.container.querySelector('.fixed')).toBeNull();
+		expect(screen.container.querySelector('[role="region"]')).toBeNull();
 	});
 
-	it('renders the upload count, speed, and uploading progress bar', async () => {
-		fixture.items = [
+	it('renders header title, completed/submitted counts, speed, and an uploading progress bar', () => {
+		fixture.queue = [
 			{
 				id: '1',
 				file: { name: 'photo.jpg' },
@@ -76,53 +124,75 @@ describe('UploadProgress', () => {
 				progress: 32
 			}
 		];
+		fixture.submitted = 2;
+		fixture.completed = 1;
 		fixture.uploadSpeed = 2048;
 
 		const screen = render(UploadProgress);
 		const text = (screen.container.textContent ?? '').replace(/\s+/g, ' ');
 
-		expect(text).toContain('Uploading 1 file');
+		expect(text).toContain('Uploading');
+		expect(text).toContain('1 of 2'); // completedCount of submittedCount
 		expect(text).toContain('2 KB/s');
 		expect(text).toContain('32%');
 		expect(text).toContain('photo.jpg');
-		expect(text).toContain('Media');
 
-		const bar = screen.container.querySelector('[role="progressbar"] > div') as HTMLElement;
-		expect(bar.style.width).toBe('32%');
+		const bars = Array.from(
+			screen.container.querySelectorAll<HTMLElement>('[role="progressbar"] > div')
+		);
+		expect(bars.some((b) => b.style.width === '32%')).toBe(true);
 	});
 
-	it('pluralizes the file label for multiple uploads', () => {
-		fixture.items = [
-			{ id: 'a', file: { name: 'a.jpg' }, libraryName: 'L', status: 'pending', progress: 0 },
-			{ id: 'b', file: { name: 'b.jpg' }, libraryName: 'L', status: 'pending', progress: 0 }
+	it('shows a "complete" title once nothing is in flight', () => {
+		fixture.queue = [
+			{ id: 'd1', file: { name: 'ok.jpg' }, libraryName: 'L', status: 'done', progress: 100 }
 		];
+		fixture.submitted = 1;
+		fixture.completed = 1;
 		const screen = render(UploadProgress);
-		const text = (screen.container.textContent ?? '').replace(/\s+/g, ' ');
-		expect(text).toContain('Uploading 2 files');
+		expect(screen.container.textContent).toContain('Upload complete');
+		expect(screen.container.textContent).toContain('Done');
+		expect(screen.container.querySelector('svg')).not.toBeNull();
 	});
 
-	it('toggles the expanded section when the header is clicked', async () => {
-		fixture.items = [
-			{ id: '2', file: { name: 'doc.pdf' }, libraryName: 'Docs', status: 'pending', progress: 0 }
+	it('renders a Cancel control for pending/uploading rows and forwards the id', () => {
+		fixture.queue = [
+			{ id: 'p1', file: { name: 'a.bin' }, libraryName: 'L', status: 'pending', progress: 0 }
+		];
+		const screen = render(UploadProgress);
+		expect(screen.container.textContent).toContain('Queued');
+
+		buttonByLabel(screen, 'Cancel upload').click();
+		expect(fixture.cancelFile).toHaveBeenCalledWith('p1');
+	});
+
+	it('shows retry/remove controls and a non-color error indicator per errored upload', () => {
+		fixture.queue = [
+			{
+				id: '3',
+				file: { name: 'report.csv' },
+				libraryName: 'Ops',
+				status: 'error',
+				progress: 0,
+				error: 'Upload failed (500)'
+			}
 		];
 
 		const screen = render(UploadProgress);
-		expect(screen.container.textContent).toContain('Waiting...');
+		expect(screen.container.textContent).toContain('Upload failed (500)');
+		// Error rows carry an icon (not color-only).
+		const row = rows(screen)[0]!;
+		expect(row.querySelector('svg')).not.toBeNull();
 
-		const header = screen.container.querySelector('button') as HTMLButtonElement;
-		header.click();
-		await vi.waitFor(() => {
-			expect(screen.container.textContent).not.toContain('Waiting...');
-		});
+		buttonByLabel(screen, 'Retry upload').click();
+		buttonByLabel(screen, 'Remove upload').click();
 
-		header.click();
-		await vi.waitFor(() => {
-			expect(screen.container.textContent).toContain('Waiting...');
-		});
+		expect(fixture.retryFile).toHaveBeenCalledWith('3');
+		expect(fixture.removeFile).toHaveBeenCalledWith('3');
 	});
 
 	it('shows the error summary and forwards retryAll / clearErrors', () => {
-		fixture.items = [
+		fixture.queue = [
 			{
 				id: 'e1',
 				file: { name: 'bad.csv' },
@@ -136,41 +206,151 @@ describe('UploadProgress', () => {
 		const screen = render(UploadProgress);
 		expect(screen.container.textContent).toContain('1 failed');
 
-		buttonByText(screen, 'Retry All').click();
+		buttonByText(screen, 'Retry all').click();
 		buttonByText(screen, 'Clear').click();
 
 		expect(fixture.retryAll).toHaveBeenCalledOnce();
 		expect(fixture.clearErrors).toHaveBeenCalledOnce();
 	});
 
-	it('shows retry/remove controls per errored upload and forwards the item id', () => {
-		fixture.items = [
+	it('offers Cancel all while uploads are in flight and forwards it', () => {
+		fixture.queue = [
+			{ id: 'u1', file: { name: 'big.mp4' }, libraryName: 'L', status: 'uploading', progress: 20 },
+			{ id: 'p2', file: { name: 'q.bin' }, libraryName: 'L', status: 'pending', progress: 0 }
+		];
+		const screen = render(UploadProgress);
+		buttonByText(screen, 'Cancel all').click();
+		expect(fixture.cancelAll).toHaveBeenCalledOnce();
+	});
+
+	it('hides Cancel all when nothing is in flight', () => {
+		fixture.queue = [
+			{ id: 'd', file: { name: 'ok.jpg' }, libraryName: 'L', status: 'done', progress: 100 }
+		];
+		const screen = render(UploadProgress);
+		const cancelAll = Array.from(screen.container.querySelectorAll('button')).find(
+			(b) => b.textContent?.trim() === 'Cancel all'
+		);
+		expect(cancelAll).toBeUndefined();
+	});
+
+	it('filters to failed uploads when the Failed tab is clicked', async () => {
+		fixture.queue = [
+			{ id: 'ok', file: { name: 'good.jpg' }, libraryName: 'L', status: 'uploading', progress: 10 },
 			{
-				id: '3',
-				file: { name: 'report.csv' },
-				libraryName: 'Ops',
+				id: 'er',
+				file: { name: 'bad.jpg' },
+				libraryName: 'L',
 				status: 'error',
 				progress: 0,
-				error: 'Upload failed (500)'
+				error: 'x'
 			}
 		];
 
 		const screen = render(UploadProgress);
-		expect(screen.container.textContent).toContain('Upload failed (500)');
+		expect(rows(screen)).toHaveLength(2);
 
-		buttonByText(screen, 'Retry').click();
-		buttonByText(screen, 'Remove').click();
-
-		expect(fixture.retryFile).toHaveBeenCalledWith('3');
-		expect(fixture.removeFile).toHaveBeenCalledWith('3');
+		buttonByText(screen, '1 failed').click();
+		await vi.waitFor(() => {
+			expect(rows(screen)).toHaveLength(1);
+		});
+		expect(screen.container.textContent).toContain('bad.jpg');
+		expect(screen.container.textContent).not.toContain('good.jpg');
 	});
 
-	it('renders a completion indicator for done uploads', () => {
-		fixture.items = [
-			{ id: 'd1', file: { name: 'ok.jpg' }, libraryName: 'L', status: 'done', progress: 100 }
+	it('collapses the list when the header is clicked', async () => {
+		fixture.queue = [
+			{ id: '2', file: { name: 'doc.pdf' }, libraryName: 'Docs', status: 'pending', progress: 0 }
 		];
+
 		const screen = render(UploadProgress);
-		expect(screen.container.textContent).toContain('Complete');
-		expect(screen.container.querySelector('svg')).not.toBeNull();
+		expect(rows(screen)).toHaveLength(1);
+
+		const header = screen.container.querySelector('button[aria-expanded]') as HTMLButtonElement;
+		header.click();
+		await vi.waitFor(() => {
+			expect(rows(screen)).toHaveLength(0);
+		});
+
+		header.click();
+		await vi.waitFor(() => {
+			expect(rows(screen)).toHaveLength(1);
+		});
+	});
+
+	it('virtualizes large queues — renders a small window with the right rows', () => {
+		fixture.queue = Array.from({ length: 500 }, (_, i) => ({
+			id: `f${i}`,
+			file: { name: `file-${i}.bin` },
+			libraryName: 'Bulk',
+			status: 'pending' as const,
+			progress: 0
+		}));
+
+		const screen = render(UploadProgress);
+		const rendered = rows(screen).length;
+		// A capped viewport at 56px rows fits a handful; with overscan it stays well
+		// under 50 — proving we don't paint all 500 at once.
+		expect(rendered).toBeGreaterThan(0);
+		expect(rendered).toBeLessThan(50);
+		// Windowing correctness: the first row is present, a far one is not.
+		expect(screen.container.textContent).toContain('file-0.bin');
+		expect(screen.container.textContent).not.toContain('file-499.bin');
+	});
+
+	it('reserves the full list height via virtual spacers (so scroll maps to all rows)', () => {
+		const ROW_H = 56;
+		const N = 500;
+		fixture.queue = Array.from({ length: N }, (_, i) => ({
+			id: `f${i}`,
+			file: { name: `file-${i}.bin` },
+			libraryName: 'Bulk',
+			status: 'pending' as const,
+			progress: 0
+		}));
+
+		const screen = render(UploadProgress);
+		const scroller = screen.container.querySelector('.overflow-y-auto') as HTMLElement;
+		expect(scroller).toBeTruthy();
+
+		// First/last children are the top/bottom virtual spacers; the rows sit between.
+		const kids = Array.from(scroller.children) as HTMLElement[];
+		const topPad = parseInt(kids[0]!.style.height || '0', 10);
+		const bottomPad = parseInt(kids[kids.length - 1]!.style.height || '0', 10);
+		const rendered = rows(screen).length;
+
+		// topPad + rendered rows + bottomPad must reconstruct the full 500-row height,
+		// i.e. the windowed DOM + spacers represent the entire queue.
+		expect(topPad + rendered * ROW_H + bottomPad).toBe(N * ROW_H);
+		expect(rendered).toBeLessThan(50);
+	});
+
+	it('warns on beforeunload only while uploads are in flight', () => {
+		fixture.queue = [
+			{ id: 'u', file: { name: 'big.mp4' }, libraryName: 'L', status: 'uploading', progress: 5 }
+		];
+		render(UploadProgress);
+
+		const evt = new Event('beforeunload', { cancelable: true });
+		window.dispatchEvent(evt);
+		expect(evt.defaultPrevented).toBe(true);
+	});
+
+	it('does not block beforeunload when nothing is in flight (errors/done only)', () => {
+		fixture.queue = [
+			{
+				id: 'e',
+				file: { name: 'bad.mp4' },
+				libraryName: 'L',
+				status: 'error',
+				progress: 0,
+				error: 'x'
+			}
+		];
+		render(UploadProgress);
+
+		const evt = new Event('beforeunload', { cancelable: true });
+		window.dispatchEvent(evt);
+		expect(evt.defaultPrevented).toBe(false);
 	});
 });

--- a/client/src/lib/state/upload-queue.svelte.ts
+++ b/client/src/lib/state/upload-queue.svelte.ts
@@ -3,59 +3,91 @@ import { apiUrl } from '$lib/api';
 import { toast } from '$lib/state/toast';
 import { getMimeTypeFromFilename } from '$lib/utils/mime-icons';
 
+export type UploadStatus = 'pending' | 'uploading' | 'error' | 'done';
+
 export interface QueuedFile {
 	id: string;
 	file: File;
 	libraryId: string;
 	libraryName: string;
 	parentFolderId: string | null;
-	status: 'pending' | 'uploading' | 'error' | 'done';
+	status: UploadStatus;
 	progress: number;
 	loaded: number;
 	total: number;
 	error?: string;
 	retries: number;
 	duplicateCount?: number;
+	/** ms timestamp set when the upload succeeds; drives the batched cleanup sweep. */
+	doneAt?: number;
 }
 
 const MAX_RETRIES = 3;
-const CONCURRENCY = 3;
+/** Simultaneous in-flight TUS uploads. */
+const CONCURRENCY = 4;
+/** How long a finished item lingers (green check) before being swept. */
 const DONE_CLEANUP_MS = 2_000;
+/** How often the batched sweep runs while finished items remain. */
+const CLEANUP_INTERVAL_MS = 1_000;
 
 const TUS_ENDPOINT = '/api/tus';
 
 /**
- * Global TUS upload queue, ported from the Nuxt `useUploadQueue` composable.
+ * App-wide TUS upload queue — a single module-level rune store shared by every
+ * consumer (so the queue keeps uploading as the user navigates the SPA, and the
+ * global progress panel reflects it everywhere).
  *
- * The Vue version shared one reactive instance across the whole app via
- * module-level `ref`s plus a `useUploadQueue()` factory that closed over the
- * per-app tus-Upload map and speed tracker. Here that global is a single
- * module-level rune store exposed via getters, so every consumer imports the
- * same instance and reactivity survives the function boundary.
+ * ## Performance model (built to stay smooth with thousands of queued files)
  *
- * No `$effect`/`watch` lives here — `addFiles`/`retryFile`/`removeFile`/etc. are
- * plain methods the consuming component calls. The internal speed tracker is a
- * `setInterval` started/stopped explicitly while uploads are draining.
+ * The old implementation derived every summary (`activeUploads`, counts, …) by
+ * `queue.filter(...)` on each read and removed finished items one-at-a-time with
+ * a per-item `setTimeout(() => queue.filter(...))`. With N files that is O(N) per
+ * summary read and O(N²) cleanup — the source of the multi-hundred-file freeze.
+ *
+ * This version keeps those costs O(1)/amortized:
+ *  - **Status counters** (`counts`) are maintained incrementally on every status
+ *    transition, so the panel header never scans the array.
+ *  - **Finished items are swept in a single batched pass** on one shared interval
+ *    instead of one timer + one filter per file.
+ *  - Progress callbacks mutate only the (≤ CONCURRENCY) in-flight items in place,
+ *    so Svelte's fine-grained reactivity re-renders just those rows — the queue
+ *    array reference is stable during progress, so the (virtualized) list is not
+ *    re-diffed on every byte.
+ *  - The `queue` array is exposed as-is so the panel can virtualize over it; the
+ *    legacy filtering getters (`activeUploads`/`erroredUploads`/…) are retained
+ *    for compatibility but are NOT used on the hot render path.
  *
  * Per-library completion/success callbacks live in two maps registered through
- * `onLibraryUploadComplete`/`onLibraryUploadSuccess`, mirroring the Vue version
- * (e.g. a library browser refreshing its file list once its uploads finish).
+ * `onLibraryUploadComplete`/`onLibraryUploadSuccess` (e.g. a library browser
+ * refreshing its file list once its uploads finish).
  */
 
-// Plain (non-reactive) bookkeeping: callback registries and live tus handles are
-// never read in `$derived`/templates, so they intentionally stay as built-in Maps.
-
+// Plain (non-reactive) bookkeeping: callback registries, live tus handles, and
+// the per-item byte cursor used for speed are never read in templates/$derived.
 const onCompleteCallbacks = new Map<string, () => void>();
 const onSuccessCallbacks = new Map<string, () => void>();
 const tusUploads = new Map<string, tus.Upload>();
+// Last `bytesUploaded` reported per item, used to derive an accurate speed delta
+// without double-counting (onProgress reports cumulative bytes, not increments).
+const speedCursors = new Map<string, number>();
 
 let queue = $state<QueuedFile[]>([]);
 let isProcessing = $state(false);
 let uploadSpeed = $state(0);
-let activeCount = $state(0);
+// O(1) status tally, maintained incrementally — never recomputed by scanning.
+const counts = $state({ pending: 0, uploading: 0, error: 0, done: 0 });
+
+// Monotonic per-session totals that drive the overall progress bar/count. Unlike
+// `counts`, these are NOT decremented when finished items are swept out of the
+// queue, so the overall percentage only moves forward during a run (it would
+// otherwise jitter/regress as the batched sweep removes done items mid-upload).
+// Both reset to 0 once the queue fully drains, so the next batch starts fresh.
+let sessionSubmitted = $state(0);
+let sessionCompleted = $state(0);
 
 let speedBytes = 0;
 let speedTimer: ReturnType<typeof setInterval> | null = null;
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
 function startSpeedTracker() {
 	if (speedTimer) return;
@@ -73,6 +105,14 @@ function stopSpeedTracker() {
 	}
 	uploadSpeed = 0;
 	speedBytes = 0;
+}
+
+/** Single source of truth for status changes — keeps `counts` in sync. */
+function setStatus(item: QueuedFile, next: UploadStatus) {
+	if (item.status === next) return;
+	counts[item.status]--;
+	counts[next]++;
+	item.status = next;
 }
 
 function addFiles(
@@ -93,8 +133,19 @@ function addFiles(
 		total: file.size,
 		retries: 0
 	}));
+	if (newItems.length === 0) return;
+	counts.pending += newItems.length;
+	sessionSubmitted += newItems.length;
 	queue = [...queue, ...newItems];
 	drainQueue();
+}
+
+/** Zero the session totals once the queue has fully drained, so the next run starts clean. */
+function resetSessionIfEmpty() {
+	if (queue.length === 0) {
+		sessionSubmitted = 0;
+		sessionCompleted = 0;
+	}
 }
 
 function drainQueue() {
@@ -103,20 +154,19 @@ function drainQueue() {
 		startSpeedTracker();
 	}
 
-	while (activeCount < CONCURRENCY) {
+	while (counts.uploading < CONCURRENCY) {
 		const next =
 			queue.find((f) => f.status === 'pending') ||
 			queue.find((f) => f.status === 'error' && f.retries < MAX_RETRIES);
 		if (!next) break;
 
-		next.status = 'uploading';
+		setStatus(next, 'uploading');
 		next.progress = 0;
 		next.loaded = 0;
-		activeCount++;
-		uploadFile(next);
+		startUpload(next);
 	}
 
-	if (activeCount === 0) {
+	if (counts.uploading === 0) {
 		isProcessing = false;
 		stopSpeedTracker();
 	}
@@ -138,7 +188,7 @@ function notifyLibraryUploadSuccess(libraryId: string) {
 	if (cb) cb();
 }
 
-function uploadFile(item: QueuedFile): void {
+function startUpload(item: QueuedFile): void {
 	const mimeType = getMimeTypeFromFilename(item.file.name);
 
 	const metadata: Record<string, string> = {
@@ -151,10 +201,15 @@ function uploadFile(item: QueuedFile): void {
 		metadata.folderId = item.parentFolderId;
 	}
 
+	speedCursors.set(item.id, 0);
+
 	const upload = new tus.Upload(item.file, {
 		endpoint: apiUrl(TUS_ENDPOINT),
 		retryDelays: [0, 1000, 3000, 5000, 10000],
 		chunkSize: 50 * 1024 * 1024,
+		// Drop the localStorage fingerprint once an upload succeeds so the browser's
+		// tus URL storage doesn't grow without bound across many uploads.
+		removeFingerprintOnSuccess: true,
 		metadata,
 		// Forward session cookie when streaming uploads cross-origin to the API.
 		onBeforeRequest(req: tus.HttpRequest) {
@@ -189,23 +244,32 @@ function uploadFile(item: QueuedFile): void {
 		},
 
 		onProgress(bytesUploaded, bytesTotal) {
+			// Ignore late callbacks from an upload that was cancelled/removed.
+			if (tusUploads.get(item.id) !== upload) return;
+
 			const optimistic = Math.round((bytesUploaded / bytesTotal) * 100);
 			if (optimistic > item.progress) {
 				item.progress = optimistic;
 			}
 			item.total = bytesTotal;
 
-			const prevLoaded = item.loaded;
-			const delta = bytesUploaded - prevLoaded;
-			if (delta > 0) {
-				speedBytes += delta;
-			}
+			// Accumulate only the *new* bytes since the last report for speed.
+			const prev = speedCursors.get(item.id) ?? 0;
+			const delta = bytesUploaded - prev;
+			if (delta > 0) speedBytes += delta;
+			speedCursors.set(item.id, bytesUploaded);
 		},
 
 		onSuccess() {
-			item.status = 'done';
+			// Ignore a success that arrives after the item was cancelled/removed.
+			if (tusUploads.get(item.id) !== upload) return;
+
+			setStatus(item, 'done');
 			item.progress = 100;
+			item.doneAt = Date.now();
+			sessionCompleted++;
 			tusUploads.delete(item.id);
+			speedCursors.delete(item.id);
 
 			if (item.duplicateCount && item.duplicateCount > 0) {
 				const n = item.duplicateCount;
@@ -217,19 +281,19 @@ function uploadFile(item: QueuedFile): void {
 			}
 
 			notifyLibraryUploadSuccess(item.libraryId);
-
-			setTimeout(() => {
-				queue = queue.filter((f) => f.id !== item.id);
-			}, DONE_CLEANUP_MS);
-
+			scheduleCleanup();
 			finish(item);
 		},
 
 		onError(error) {
-			item.status = 'error';
+			// Ignore an error from an upload that was cancelled/removed.
+			if (tusUploads.get(item.id) !== upload) return;
+
+			setStatus(item, 'error');
 			item.error = error.message || 'Upload failed';
 			item.retries++;
 			tusUploads.delete(item.id);
+			speedCursors.delete(item.id);
 			finish(item);
 		}
 	});
@@ -237,6 +301,11 @@ function uploadFile(item: QueuedFile): void {
 	tusUploads.set(item.id, upload);
 
 	upload.findPreviousUploads().then((previousUploads) => {
+		// `start()` runs a microtask after the handle is registered, so a cancel can
+		// land in between. Bail if this handle is no longer the live one for the item
+		// (removed, or superseded by a retry) — otherwise we'd spin up an orphaned,
+		// untracked upload that can never be aborted and pins the File from GC.
+		if (tusUploads.get(item.id) !== upload) return;
 		if (previousUploads.length > 0 && previousUploads[0]) {
 			upload.resumeFromPreviousUpload(previousUploads[0]);
 		}
@@ -245,16 +314,47 @@ function uploadFile(item: QueuedFile): void {
 }
 
 function finish(item: QueuedFile) {
-	activeCount--;
 	notifyLibraryIfIdle(item.libraryId);
 	drainQueue();
+}
+
+/**
+ * Remove finished items in a single batched pass on a shared interval. This
+ * replaces the old per-item `setTimeout(() => queue.filter())`, which was O(N²)
+ * over a large queue.
+ */
+function scheduleCleanup() {
+	if (cleanupTimer) return;
+	cleanupTimer = setInterval(sweepFinished, CLEANUP_INTERVAL_MS);
+}
+
+function sweepFinished() {
+	const now = Date.now();
+	let removed = 0;
+	queue = queue.filter((f) => {
+		if (f.status === 'done' && now - (f.doneAt ?? now) >= DONE_CLEANUP_MS) {
+			removed++;
+			return false;
+		}
+		return true;
+	});
+	if (removed > 0) counts.done -= removed;
+
+	resetSessionIfEmpty();
+
+	// Stop sweeping once no finished items remain awaiting cleanup.
+	if (counts.done === 0 && cleanupTimer) {
+		clearInterval(cleanupTimer);
+		cleanupTimer = null;
+	}
 }
 
 function retryFile(itemId: string) {
 	const item = queue.find((f) => f.id === itemId);
 	if (item && item.status === 'error') {
-		item.status = 'pending';
+		setStatus(item, 'pending');
 		item.retries = 0;
+		item.error = undefined;
 		drainQueue();
 	}
 }
@@ -262,24 +362,79 @@ function retryFile(itemId: string) {
 function retryAll() {
 	for (const item of queue) {
 		if (item.status === 'error') {
-			item.status = 'pending';
+			setStatus(item, 'pending');
 			item.retries = 0;
+			item.error = undefined;
 		}
 	}
 	drainQueue();
 }
 
+/**
+ * Cancel/remove a single item. Aborts the in-flight tus upload if any, frees its
+ * concurrency slot, and pulls the next pending file forward.
+ */
 function removeFile(itemId: string) {
+	const item = queue.find((f) => f.id === itemId);
+	if (!item) return;
+
 	const upload = tusUploads.get(itemId);
 	if (upload) {
 		upload.abort(false);
 		tusUploads.delete(itemId);
 	}
+	speedCursors.delete(itemId);
+
+	const wasInFlight = item.status === 'uploading' || item.status === 'pending';
+	counts[item.status]--;
+	// A removed item won't contribute to the session total any more. If it had
+	// already completed, drop it from the completed tally too so the ratio holds.
+	sessionSubmitted = Math.max(0, sessionSubmitted - 1);
+	if (item.status === 'done') sessionCompleted = Math.max(0, sessionCompleted - 1);
 	queue = queue.filter((f) => f.id !== itemId);
+	resetSessionIfEmpty();
+
+	// Removing an active item frees a slot — keep throughput up by refilling it.
+	if (wasInFlight) drainQueue();
+}
+
+/** Alias for {@link removeFile} — clearer intent for an in-flight cancel. */
+function cancelFile(itemId: string) {
+	removeFile(itemId);
+}
+
+/**
+ * Cancel every pending/in-flight upload in one batched pass (errored items are
+ * left so they can still be retried or cleared). O(N), not O(N²).
+ */
+function cancelAll() {
+	const remaining = counts.pending + counts.uploading;
+	if (remaining === 0) return;
+
+	for (const item of queue) {
+		if (item.status === 'pending' || item.status === 'uploading') {
+			const upload = tusUploads.get(item.id);
+			if (upload) {
+				upload.abort(false);
+				tusUploads.delete(item.id);
+			}
+			speedCursors.delete(item.id);
+		}
+	}
+	counts.pending = 0;
+	counts.uploading = 0;
+	sessionSubmitted = Math.max(sessionCompleted, sessionSubmitted - remaining);
+	queue = queue.filter((f) => f.status !== 'pending' && f.status !== 'uploading');
+	resetSessionIfEmpty();
+	drainQueue();
 }
 
 function clearErrors() {
+	if (counts.error === 0) return;
+	sessionSubmitted = Math.max(sessionCompleted, sessionSubmitted - counts.error);
+	counts.error = 0;
 	queue = queue.filter((f) => f.status !== 'error');
+	resetSessionIfEmpty();
 }
 
 function onLibraryUploadComplete(libraryId: string, callback: () => void) {
@@ -299,16 +454,31 @@ function removeOnSuccess(libraryId: string) {
 }
 
 /**
- * Reset all reactive state + registered callbacks + the speed tracker. Primarily
- * for tests; also safe to call on logout. Does not abort in-flight tus uploads.
+ * Reset all reactive state + registered callbacks + timers, aborting any in-flight
+ * tus uploads. Used by tests and on logout / when the authed shell unmounts, so an
+ * abandoned session doesn't leave orphaned uploads, timers, or File references alive.
  */
 function reset() {
 	stopSpeedTracker();
+	if (cleanupTimer) {
+		clearInterval(cleanupTimer);
+		cleanupTimer = null;
+	}
+	for (const upload of tusUploads.values()) {
+		// abort(true) terminates the transfer and clears its localStorage fingerprint.
+		Promise.resolve(upload.abort(true)).catch(() => {});
+	}
 	queue = [];
 	isProcessing = false;
 	uploadSpeed = 0;
-	activeCount = 0;
+	counts.pending = 0;
+	counts.uploading = 0;
+	counts.error = 0;
+	counts.done = 0;
+	sessionSubmitted = 0;
+	sessionCompleted = 0;
 	tusUploads.clear();
+	speedCursors.clear();
 	onCompleteCallbacks.clear();
 	onSuccessCallbacks.clear();
 }
@@ -324,17 +494,45 @@ export const uploadQueue = {
 	get uploadSpeed() {
 		return uploadSpeed;
 	},
-	get activeCount() {
-		return activeCount;
+	// O(1) status tallies — prefer these over the filtering getters below.
+	get pendingCount() {
+		return counts.pending;
 	},
-	get activeUploads() {
-		return queue.filter((f) => f.status !== 'done');
+	get uploadingCount() {
+		return counts.uploading;
+	},
+	get errorCount() {
+		return counts.error;
+	},
+	get doneCount() {
+		return counts.done;
+	},
+	get totalCount() {
+		return queue.length;
+	},
+	// Monotonic per-session totals for the overall progress display (don't jitter
+	// when finished items are swept out of the queue mid-run).
+	get submittedCount() {
+		return sessionSubmitted;
+	},
+	get completedCount() {
+		return sessionCompleted;
+	},
+	get overallProgress() {
+		return sessionSubmitted > 0 ? Math.round((sessionCompleted / sessionSubmitted) * 100) : 0;
+	},
+	get activeCount() {
+		return counts.uploading;
 	},
 	get hasActiveUploads() {
-		return queue.filter((f) => f.status !== 'done').length > 0;
+		return queue.length > 0;
 	},
 	get hasInFlightUploads() {
-		return queue.some((f) => f.status === 'pending' || f.status === 'uploading');
+		return counts.pending > 0 || counts.uploading > 0;
+	},
+	// Legacy filtering getters — retained for compatibility; not on the hot path.
+	get activeUploads() {
+		return queue.filter((f) => f.status !== 'done');
 	},
 	get erroredUploads() {
 		return queue.filter((f) => f.status === 'error');
@@ -346,6 +544,8 @@ export const uploadQueue = {
 	retryFile,
 	retryAll,
 	removeFile,
+	cancelFile,
+	cancelAll,
 	clearErrors,
 	onLibraryUploadComplete,
 	removeOnComplete,

--- a/client/src/lib/state/upload-queue.test.ts
+++ b/client/src/lib/state/upload-queue.test.ts
@@ -187,30 +187,32 @@ describe('uploadQueue — upload lifecycle', () => {
 		expect(uploadQueue.isProcessing).toBe(false);
 	});
 
-	it('uploads multiple files concurrently (up to 3)', async () => {
-		const files = Array.from({ length: 5 }, (_, i) => new File([`data${i}`], `file${i}.txt`));
+	it('uploads multiple files concurrently (up to 4)', async () => {
+		const files = Array.from({ length: 6 }, (_, i) => new File([`data${i}`], `file${i}.txt`));
 
 		uploadQueue.addFiles(files, 'lib-1', 'Library One');
 		await flushPromises();
 
-		// Should have started 3 concurrent uploads
-		expect(MockTusUpload.instances).toHaveLength(3);
-		expect(uploadQueue.queue.filter((f) => f.status === 'uploading')).toHaveLength(3);
+		// Should have started 4 concurrent uploads
+		expect(MockTusUpload.instances).toHaveLength(4);
+		expect(uploadQueue.queue.filter((f) => f.status === 'uploading')).toHaveLength(4);
 		expect(uploadQueue.queue.filter((f) => f.status === 'pending')).toHaveLength(2);
+		expect(uploadQueue.uploadingCount).toBe(4);
+		expect(uploadQueue.pendingCount).toBe(2);
 
-		// Complete the first upload — should start the 4th
+		// Complete the first upload — should start the 5th
 		MockTusUpload.instances[0]!.triggerSuccess();
 		await flushPromises();
 
-		expect(MockTusUpload.instances).toHaveLength(4);
-		expect(uploadQueue.queue.filter((f) => f.status === 'uploading')).toHaveLength(3);
+		expect(MockTusUpload.instances).toHaveLength(5);
+		expect(uploadQueue.queue.filter((f) => f.status === 'uploading')).toHaveLength(4);
 		expect(uploadQueue.queue.filter((f) => f.status === 'pending')).toHaveLength(1);
 
-		// Complete the second — should start the 5th
+		// Complete the second — should start the 6th
 		MockTusUpload.instances[1]!.triggerSuccess();
 		await flushPromises();
 
-		expect(MockTusUpload.instances).toHaveLength(5);
+		expect(MockTusUpload.instances).toHaveLength(6);
 		expect(uploadQueue.queue.filter((f) => f.status === 'pending')).toHaveLength(0);
 	});
 
@@ -641,5 +643,357 @@ describe('uploadQueue — derived getters', () => {
 		const item = queued({ id: '1', status: 'done' });
 		expect(item.id).toBe('1');
 		expect(item.status).toBe('done');
+	});
+});
+
+describe('uploadQueue — O(1) counters', () => {
+	it('keeps status counters in sync through the upload lifecycle', async () => {
+		const files = Array.from({ length: 6 }, (_, i) => new File([`d${i}`], `f${i}.txt`));
+		uploadQueue.addFiles(files, 'lib-1', 'Library One');
+		await flushPromises();
+
+		// 4 uploading (concurrency), 2 pending, 0 error/done.
+		expect(uploadQueue.uploadingCount).toBe(4);
+		expect(uploadQueue.pendingCount).toBe(2);
+		expect(uploadQueue.errorCount).toBe(0);
+		expect(uploadQueue.doneCount).toBe(0);
+		expect(uploadQueue.totalCount).toBe(6);
+
+		// One success: uploading 4→3 then drain pulls a pending up → uploading 4, done 1, pending 1.
+		MockTusUpload.instances[0]!.triggerSuccess();
+		await flushPromises();
+		expect(uploadQueue.doneCount).toBe(1);
+		expect(uploadQueue.uploadingCount).toBe(4);
+		expect(uploadQueue.pendingCount).toBe(1);
+
+		// Counters must always equal a fresh recompute over the queue.
+		const recompute = (s: string) => uploadQueue.queue.filter((f) => f.status === s).length;
+		expect(uploadQueue.uploadingCount).toBe(recompute('uploading'));
+		expect(uploadQueue.pendingCount).toBe(recompute('pending'));
+		expect(uploadQueue.doneCount).toBe(recompute('done'));
+		expect(uploadQueue.errorCount).toBe(recompute('error'));
+	});
+});
+
+describe('uploadQueue — cancel + slot refill', () => {
+	it('cancelFile aborts an in-flight upload and pulls the next pending file forward', async () => {
+		const files = Array.from({ length: 5 }, (_, i) => new File([`d${i}`], `f${i}.txt`));
+		uploadQueue.addFiles(files, 'lib-1', 'Library One');
+		await flushPromises();
+
+		// 4 uploading, 1 pending.
+		expect(uploadQueue.uploadingCount).toBe(4);
+		expect(uploadQueue.pendingCount).toBe(1);
+		const inFlight = MockTusUpload.instances[0]!;
+		const cancelId = uploadQueue.queue[0]!.id;
+
+		uploadQueue.cancelFile(cancelId);
+		await flushPromises();
+
+		// The tus upload was aborted, the item is gone, and the freed slot was refilled
+		// by the previously-pending file (so a 5th tus upload started).
+		expect(inFlight.aborted).toBe(true);
+		expect(uploadQueue.queue.some((f) => f.id === cancelId)).toBe(false);
+		expect(uploadQueue.uploadingCount).toBe(4);
+		expect(uploadQueue.pendingCount).toBe(0);
+		expect(MockTusUpload.instances).toHaveLength(5);
+	});
+
+	it('cancelling a pending item does not start an extra upload', async () => {
+		const files = Array.from({ length: 6 }, (_, i) => new File([`d${i}`], `f${i}.txt`));
+		uploadQueue.addFiles(files, 'lib-1', 'Library One');
+		await flushPromises();
+
+		expect(MockTusUpload.instances).toHaveLength(4); // 4 in-flight, 2 pending
+		const pendingItem = uploadQueue.queue.find((f) => f.status === 'pending')!;
+
+		uploadQueue.cancelFile(pendingItem.id);
+		await flushPromises();
+
+		// A pending cancel frees no slot, so no new upload starts; one pending remains.
+		expect(MockTusUpload.instances).toHaveLength(4);
+		expect(uploadQueue.pendingCount).toBe(1);
+		expect(uploadQueue.totalCount).toBe(5);
+	});
+});
+
+describe('uploadQueue — batched cleanup', () => {
+	it('sweeps many finished items in a single pass once they age out', async () => {
+		const files = Array.from({ length: 4 }, (_, i) => new File([`d${i}`], `f${i}.txt`));
+		uploadQueue.addFiles(files, 'lib-1', 'Library One');
+		await flushPromises();
+
+		// Complete all 4 concurrently.
+		for (const inst of MockTusUpload.instances) inst.triggerSuccess();
+		await flushPromises();
+
+		expect(uploadQueue.doneCount).toBe(4);
+		expect(uploadQueue.totalCount).toBe(4);
+
+		// After the cleanup window the batched sweep removes them all and the queue empties.
+		vi.advanceTimersByTime(3000);
+		await flushPromises();
+
+		expect(uploadQueue.totalCount).toBe(0);
+		expect(uploadQueue.doneCount).toBe(0);
+		expect(uploadQueue.hasActiveUploads).toBe(false);
+	});
+});
+
+describe('uploadQueue — overall progress (monotonic)', () => {
+	it('does not regress when the sweep removes done items mid-run, and resets when empty', async () => {
+		const files = Array.from({ length: 4 }, (_, i) => new File([`d${i}`], `f${i}.txt`));
+		uploadQueue.addFiles(files, 'lib-1', 'Library One');
+		await flushPromises();
+
+		expect(uploadQueue.submittedCount).toBe(4);
+		expect(uploadQueue.overallProgress).toBe(0);
+
+		// Two of four complete → 50%.
+		MockTusUpload.instances[0]!.triggerSuccess();
+		MockTusUpload.instances[1]!.triggerSuccess();
+		await flushPromises();
+		expect(uploadQueue.completedCount).toBe(2);
+		expect(uploadQueue.overallProgress).toBe(50);
+
+		// The sweep removes the two done items, but progress must NOT drop back toward 0.
+		vi.advanceTimersByTime(3000);
+		await flushPromises();
+		expect(uploadQueue.doneCount).toBe(0); // swept out of the queue
+		expect(uploadQueue.overallProgress).toBe(50); // monotonic
+
+		// Finish the rest → 100%, then everything sweeps and the session resets.
+		MockTusUpload.instances[2]!.triggerSuccess();
+		MockTusUpload.instances[3]!.triggerSuccess();
+		await flushPromises();
+		expect(uploadQueue.overallProgress).toBe(100);
+
+		vi.advanceTimersByTime(3000);
+		await flushPromises();
+		expect(uploadQueue.totalCount).toBe(0);
+		expect(uploadQueue.submittedCount).toBe(0);
+		expect(uploadQueue.overallProgress).toBe(0);
+	});
+});
+
+describe('uploadQueue — cancelAll', () => {
+	it('aborts every pending/in-flight upload in one pass and stops processing', async () => {
+		const files = Array.from({ length: 6 }, (_, i) => new File([`d${i}`], `f${i}.txt`));
+		uploadQueue.addFiles(files, 'lib-1', 'Library One');
+		await flushPromises();
+
+		expect(uploadQueue.uploadingCount).toBe(4);
+		expect(uploadQueue.pendingCount).toBe(2);
+
+		uploadQueue.cancelAll();
+		await flushPromises();
+
+		// All four in-flight tus uploads aborted; nothing left in the queue.
+		expect(MockTusUpload.instances.every((i) => i.aborted)).toBe(true);
+		expect(uploadQueue.totalCount).toBe(0);
+		expect(uploadQueue.uploadingCount).toBe(0);
+		expect(uploadQueue.pendingCount).toBe(0);
+		expect(uploadQueue.hasInFlightUploads).toBe(false);
+		expect(uploadQueue.isProcessing).toBe(false);
+	});
+
+	it('leaves errored items in place so they can still be retried', async () => {
+		const files = [new File(['a'], 'a.txt'), new File(['b'], 'b.txt')];
+		uploadQueue.addFiles(files, 'lib-1', 'Library One');
+		await flushPromises();
+
+		// Drive the second file to a terminal error (exhaust retries).
+		while (uploadQueue.errorCount === 0) {
+			for (const inst of MockTusUpload.instances) {
+				if (inst.started && !inst.aborted) inst.triggerError('fail');
+			}
+			await flushPromises();
+			if (MockTusUpload.instances.length > 20) break; // safety
+		}
+		expect(uploadQueue.errorCount).toBeGreaterThanOrEqual(1);
+
+		uploadQueue.cancelAll();
+		await flushPromises();
+
+		// Errors remain; only pending/uploading were cancelled.
+		expect(uploadQueue.errorCount).toBeGreaterThanOrEqual(1);
+		expect(uploadQueue.uploadingCount).toBe(0);
+		expect(uploadQueue.pendingCount).toBe(0);
+		expect(uploadQueue.hasInFlightUploads).toBe(false);
+	});
+});
+
+describe('uploadQueue — cancel during the findPreviousUploads window', () => {
+	it('does not start an orphaned upload when cancelled before start()', async () => {
+		const file = new File(['x'], 'race.txt');
+		// Do NOT flush — start() runs in the findPreviousUploads().then microtask.
+		uploadQueue.addFiles([file], 'lib-1', 'Library One');
+
+		const inst = MockTusUpload.instances[0]!;
+		expect(inst.started).toBe(false); // not started yet
+		const id = uploadQueue.queue[0]!.id;
+
+		uploadQueue.cancelFile(id);
+		await flushPromises();
+
+		// The deferred start was guarded out — no orphaned, untracked upload.
+		expect(inst.started).toBe(false);
+		expect(inst.aborted).toBe(true);
+		expect(uploadQueue.uploadingCount).toBe(0);
+		expect(uploadQueue.totalCount).toBe(0);
+	});
+
+	it('ignores a late onError/onSuccess from a removed item (no negative counters)', async () => {
+		const file = new File(['x'], 'late.txt');
+		uploadQueue.addFiles([file], 'lib-1', 'Library One');
+		await flushPromises();
+
+		const inst = MockTusUpload.instances[0]!;
+		const id = uploadQueue.queue[0]!.id;
+		uploadQueue.removeFile(id);
+
+		// A late callback from the aborted upload must be a no-op.
+		inst.triggerError('late failure');
+		inst.triggerSuccess();
+		await flushPromises();
+
+		expect(uploadQueue.uploadingCount).toBe(0);
+		expect(uploadQueue.errorCount).toBe(0);
+		expect(uploadQueue.doneCount).toBe(0);
+		expect(uploadQueue.totalCount).toBe(0);
+	});
+});
+
+describe('uploadQueue — remove on terminal items + empty add', () => {
+	it('removeFile on an errored item clears it without refilling a slot', async () => {
+		const file = new File(['x'], 'err.txt');
+		uploadQueue.addFiles([file], 'lib-1', 'Library One');
+		await flushPromises();
+
+		// Exhaust retries → error.
+		while (uploadQueue.errorCount === 0) {
+			for (const inst of MockTusUpload.instances) {
+				if (inst.started && !inst.aborted) inst.triggerError('fail');
+			}
+			await flushPromises();
+			if (MockTusUpload.instances.length > 20) break;
+		}
+		const before = MockTusUpload.instances.length;
+		const id = uploadQueue.queue[0]!.id;
+
+		uploadQueue.removeFile(id);
+		expect(uploadQueue.errorCount).toBe(0);
+		expect(uploadQueue.totalCount).toBe(0);
+		expect(MockTusUpload.instances.length).toBe(before); // no drain/refill
+	});
+
+	it('removeFile on a done item before the sweep leaves no negative count', async () => {
+		const file = new File(['x'], 'ok.txt');
+		uploadQueue.addFiles([file], 'lib-1', 'Library One');
+		await flushPromises();
+		MockTusUpload.instances[0]!.triggerSuccess();
+		await flushPromises();
+
+		const id = uploadQueue.queue[0]!.id;
+		uploadQueue.removeFile(id);
+		expect(uploadQueue.doneCount).toBe(0);
+		expect(uploadQueue.totalCount).toBe(0);
+
+		vi.advanceTimersByTime(3000);
+		await flushPromises();
+		expect(uploadQueue.doneCount).toBe(0); // sweep didn't double-decrement
+	});
+
+	it('addFiles with an empty array is a no-op', () => {
+		uploadQueue.addFiles([], 'lib-1', 'Library One');
+		expect(uploadQueue.totalCount).toBe(0);
+		expect(uploadQueue.isProcessing).toBe(false);
+		expect(MockTusUpload.instances).toHaveLength(0);
+	});
+});
+
+describe('uploadQueue — counters cross-check & invariants', () => {
+	it('all four counters equal a fresh recompute across done/error/retry/sweep', async () => {
+		const files = [new File(['a'], 'a.txt'), new File(['b'], 'b.txt')];
+		uploadQueue.addFiles(files, 'lib-1', 'Library One');
+		await flushPromises();
+
+		// One success → done.
+		MockTusUpload.instances[0]!.triggerSuccess();
+		await flushPromises();
+
+		// Second → terminal error.
+		while (uploadQueue.errorCount === 0) {
+			for (const inst of MockTusUpload.instances) {
+				if (inst.started && !inst.aborted) inst.triggerError('fail');
+			}
+			await flushPromises();
+			if (MockTusUpload.instances.length > 20) break;
+		}
+
+		const recompute = (s: QueuedFile['status']) =>
+			uploadQueue.queue.filter((f) => f.status === s).length;
+		const check = () => {
+			expect(uploadQueue.pendingCount).toBe(recompute('pending'));
+			expect(uploadQueue.uploadingCount).toBe(recompute('uploading'));
+			expect(uploadQueue.doneCount).toBe(recompute('done'));
+			expect(uploadQueue.errorCount).toBe(recompute('error'));
+		};
+		check();
+
+		// Manual retry: error → pending → uploading.
+		uploadQueue.retryFile(uploadQueue.queue.find((f) => f.status === 'error')!.id);
+		await flushPromises();
+		check();
+
+		// Sweep removes the done item.
+		vi.advanceTimersByTime(3000);
+		await flushPromises();
+		check();
+	});
+
+	it('reports no in-flight uploads when every file has errored (beforeunload guard input)', async () => {
+		const files = [new File(['a'], 'a.txt'), new File(['b'], 'b.txt')];
+		uploadQueue.addFiles(files, 'lib-1', 'Library One');
+		await flushPromises();
+
+		while (uploadQueue.queue.some((f) => f.status !== 'error')) {
+			for (const inst of MockTusUpload.instances) {
+				if (inst.started && !inst.aborted) inst.triggerError('fail');
+			}
+			await flushPromises();
+			if (MockTusUpload.instances.length > 40) break;
+		}
+
+		expect(uploadQueue.errorCount).toBe(2);
+		expect(uploadQueue.hasInFlightUploads).toBe(false); // → beforeunload would NOT block
+		expect(uploadQueue.hasActiveUploads).toBe(true); // panel stays visible to show failures
+	});
+
+	it('keeps the queue array reference stable across in-place progress mutation', async () => {
+		const file = new File(['x'.repeat(100)], 'stable.bin');
+		uploadQueue.addFiles([file], 'lib-1', 'Library One');
+		await flushPromises();
+
+		const ref = uploadQueue.queue;
+		MockTusUpload.instances[0]!.triggerProgress(700, 1000);
+		expect(uploadQueue.queue).toBe(ref); // mutated in place, not reassigned
+		expect(uploadQueue.currentUpload?.progress).toBe(70);
+
+		// A structural change (adding files) DOES create a new array reference.
+		uploadQueue.addFiles([new File(['y'], 'y.txt')], 'lib-1', 'Library One');
+		expect(uploadQueue.queue).not.toBe(ref);
+	});
+
+	it('attributes speed across concurrent uploads without overwriting', async () => {
+		const files = [new File(['a'], 'a.txt'), new File(['b'], 'b.txt')];
+		uploadQueue.addFiles(files, 'lib-1', 'Library One');
+		await flushPromises();
+
+		// Two concurrent uploads report progress within the same sampling window.
+		MockTusUpload.instances[0]!.triggerProgress(600, 5000);
+		MockTusUpload.instances[1]!.triggerProgress(400, 5000);
+		vi.advanceTimersByTime(500);
+		expect(uploadQueue.uploadSpeed).toBe((600 + 400) * 2); // summed, not last-wins
 	});
 });

--- a/client/src/routes/(app)/+layout.svelte
+++ b/client/src/routes/(app)/+layout.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { page } from '$app/state';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { Dialog, Popover } from '@skeletonlabs/skeleton-svelte';
 	import { api } from '$lib/api';
 	import { auth } from '$lib/state/auth.svelte';
 	import { registerLibrariesRefresh } from '$lib/state/libraries-list.svelte';
+	import { uploadQueue } from '$lib/state/upload-queue.svelte';
 	import { ICONS } from '$lib/utils/icons';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
 	import UserAvatar from '$lib/components/ui/UserAvatar.svelte';
 	import SidebarLibraryNav from '$lib/components/SidebarLibraryNav.svelte';
 	import NotificationBell from '$lib/components/notifications/NotificationBell.svelte';
+	import UploadProgress from '$lib/components/UploadProgress.svelte';
 	import type { LayoutProps } from './$types';
 
 	/**
@@ -44,6 +46,11 @@
 	onMount(() => {
 		registerLibrariesRefresh(() => invalidateAll());
 	});
+
+	// The authed shell unmounts on logout / leaving the app group — tear down the
+	// global upload queue (abort in-flight uploads, clear timers/handles) so an
+	// abandoned session doesn't leak uploads or File references.
+	onDestroy(() => uploadQueue.reset());
 
 	function submitGlobalSearch() {
 		const q = globalSearchQuery.trim();
@@ -208,3 +215,6 @@
 		</main>
 	</div>
 </div>
+
+<!-- App-wide upload progress: pinned bottom-right, persists across navigation. -->
+<UploadProgress />

--- a/client/test/e2e/upload.e2e.ts
+++ b/client/test/e2e/upload.e2e.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { login } from './helpers/auth';
+
+// 1×1 transparent PNG — a tiny, valid image so the real backend accepts and
+// processes the upload without special-casing the file type.
+const TINY_PNG = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+	'base64'
+);
+
+// Full-stack upload flow against the seeded backend: queue a file through the
+// modal, watch the app-wide upload panel report progress, and confirm the file
+// lands in the library once the queue drains.
+test.describe('upload queue (full stack)', () => {
+	test('uploads a file via the modal and the global panel reports it to completion', async ({
+		page
+	}) => {
+		await login(page);
+		await expect(page).toHaveURL(/\/libraries\//, { timeout: 15_000 });
+
+		// Unique name so the file is unambiguous in both the panel and the grid.
+		const name = `e2e-upload-${Date.now()}-${Math.floor(Math.random() * 1e6)}.png`;
+
+		// Open the upload modal from the toolbar (only one "Upload" button until it opens).
+		await page.getByRole('button', { name: 'Upload' }).filter({ visible: true }).first().click();
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+		await dialog.locator('input[type="file"]').setInputFiles({
+			name,
+			mimeType: 'image/png',
+			buffer: TINY_PNG
+		});
+		await expect(dialog.getByText(/1 file selected/i)).toBeVisible();
+
+		// Submit — queues onto the global upload queue and closes the modal.
+		await dialog.getByRole('button', { name: 'Upload' }).click();
+
+		// The app-wide panel appears bottom-right and shows this file.
+		const panel = page.getByRole('region', { name: 'Upload progress' });
+		await expect(panel).toBeVisible({ timeout: 15_000 });
+		await expect(panel.getByText(name)).toBeVisible({ timeout: 15_000 });
+
+		// Once everything finishes the done items are swept and the panel hides.
+		await expect(panel).toBeHidden({ timeout: 45_000 });
+
+		// The uploaded file is now part of the library (the browser auto-refreshes
+		// after its uploads complete).
+		await expect(page.getByText(name).first()).toBeVisible({ timeout: 15_000 });
+	});
+
+	test('the panel keeps an in-flight upload visible across navigation', async ({ page }) => {
+		await login(page);
+		await expect(page).toHaveURL(/\/libraries\//, { timeout: 15_000 });
+
+		// Slow the TUS requests so the upload is genuinely still in flight when we
+		// navigate — otherwise tiny files finish instantly and the assertion is vacuous.
+		await page.route('**/api/tus**', async (route) => {
+			await new Promise((r) => setTimeout(r, 2000));
+			await route.continue();
+		});
+
+		const name = `e2e-nav-${Date.now()}-${Math.floor(Math.random() * 1e6)}.png`;
+
+		await page.getByRole('button', { name: 'Upload' }).filter({ visible: true }).first().click();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 10_000 });
+		await dialog.locator('input[type="file"]').setInputFiles({
+			name,
+			mimeType: 'image/png',
+			buffer: TINY_PNG
+		});
+		await dialog.getByRole('button', { name: 'Upload' }).click();
+
+		const panel = page.getByRole('region', { name: 'Upload progress' });
+		await expect(panel).toBeVisible({ timeout: 15_000 });
+
+		// Navigate to the Timeline tab while the upload is still in flight — the queue
+		// panel is mounted on the (app) layout, so it must stay visible (and still show
+		// this file) across the in-app navigation.
+		await page
+			.getByRole('link', { name: /timeline/i })
+			.filter({ visible: true })
+			.first()
+			.click();
+		await expect(page).toHaveURL(/\/timeline$/, { timeout: 15_000 });
+		// The guarantee under test: the still-uploading panel and its file persist
+		// across the in-app navigation (the panel lives on the layout, not the page).
+		await expect(panel).toBeVisible();
+		await expect(panel.getByText(name)).toBeVisible();
+
+		// Stop throttling so the in-flight upload can drain on context teardown.
+		await page.unroute('**/api/tus**');
+	});
+});

--- a/website/src/content/docs/features/files-folders-and-uploads.md
+++ b/website/src/content/docs/features/files-folders-and-uploads.md
@@ -53,15 +53,27 @@ Alcoves uses the **TUS resumable upload protocol**, which means uploads survive 
 ### How to start an upload
 
 1. Drag one or more files onto the library browser, or click the **Upload** button and use the file picker.
-2. Alcoves begins uploading up to three files at a time. A floating panel in the bottom-right corner shows per-file progress and the aggregate upload speed.
+2. Alcoves begins uploading up to four files at a time. A floating panel in the bottom-right corner shows per-file progress, completed/total counts, and the aggregate upload speed.
 3. If a file was already uploaded before (identical content), you see a warning toast — the duplicate is still stored but flagged.
+
+### The upload panel
+
+The progress panel is **app-wide**: it stays pinned to the bottom-right and keeps uploading even as you move between libraries, the timeline, settings, or any other page — it only disappears once the queue is fully drained. You can collapse it to a compact header while it works.
+
+Each file in the queue has its own row:
+
+- **Cancel** a queued or in-progress upload to abort it and free its slot for the next file.
+- **Retry** a failed upload (or **Retry all**) to re-queue it; **Clear** removes all failed entries.
+- A **Failed** filter lets you jump straight to errored files when a large batch has a few failures.
+
+The list is built to stay smooth with very large batches — queuing thousands of files at once will not freeze the panel, because only the rows currently on screen are rendered.
 
 ### Resumable uploads
 
 Uploads run in 50 MB chunks. If your connection drops, the upload pauses automatically. It retries up to three times with increasing back-off delays before marking the file as failed. You can retry a failed upload manually from the progress panel.
 
 :::note
-Closing the browser tab while an upload is in progress shows a confirmation prompt so you do not accidentally lose an in-flight transfer.
+Reloading or closing the browser tab while an upload is in progress shows a confirmation prompt so you do not accidentally abort an in-flight transfer.
 :::
 
 ### Who can upload


### PR DESCRIPTION
## Why

Uploading a few hundred files froze the upload UI, and the upload-progress panel (`UploadProgress.svelte`) was never actually mounted anywhere — uploads happened invisibly. This rebuilds uploads into a real, app-wide upload manager that stays smooth with thousands of files.

Closes the request: an app-wide queue that keeps uploading as you move around the app, stays pinned bottom-right until the queue empties, shows per-file progress at 4 concurrent uploads, supports per-file cancel + retry, warns before reload while uploading, and never freezes on large batches.

## What changed

**Store — `upload-queue.svelte.ts`**
- **O(1) status counters** maintained incrementally, instead of `queue.filter(...)` on every read/progress tick — the main freeze cause.
- **Batched single-pass cleanup sweep** of finished items, replacing the old per-item `setTimeout` + `filter` (which was **O(N²)** over a large queue).
- **Concurrency 3 → 4.**
- **Cancel** (`cancelFile`) aborts the in-flight upload and refills the freed slot; **`cancelAll`** cancels everything in one pass (errors are kept for retry). Remove-while-uploading now frees its slot too.
- **Leak/race fixes** (from review): a cancel during the `findPreviousUploads()` window can no longer start an orphaned, untracked upload; late `onProgress`/`onSuccess`/`onError` from a removed item are ignored; `reset()` aborts in-flight uploads on teardown.
- **Monotonic per-session totals** drive the overall progress so it never regresses when the sweep removes done items mid-run; accurate per-upload speed (no cross-upload double counting); `removeFingerprintOnSuccess` to bound localStorage growth.

**Panel — `UploadProgress.svelte` + `(app)/+layout.svelte`**
- Mounted **once in the authed layout** so it persists across SPA navigation and stays visible until the queue drains.
- **Virtualized** fixed-height row list — only on-screen rows render, so thousands of files stay smooth (**verified: 600 files render in ~80 ms with ~18 rows in the DOM**).
- Per-file **Cancel/Retry**, **Retry-all/Clear**, **Cancel-all**, a **Failed** filter, overall progress + speed, a **`beforeunload` reload guard**, responsive height, non-color error indicators, and focus-return after row actions.
- Layout `reset()`s the queue on unmount/logout to avoid leaking uploads/timers.

## How it was verified

- **Adversarial multi-agent review** (5 dimensions → skeptical verification of each finding): 23 confirmed issues triaged; the HIGH leak/race + the MEDIUM correctness/UX issues are fixed in this PR, with regression tests for each.
- `bun run typecheck && lint && test:unit` → **1639 unit tests pass**; coverage gates pass (store 100% lines, panel 98%).
- `bun run test:e2e` against the **real seeded stack** → new `upload.e2e.ts` (upload-to-completion + panel persistence across navigation) plus the full functional suite (auth/library/admin/share/mobile-nav) all green.
- Manual browser perf check with 600 queued files: panel responsive, virtualization holds, no freeze.

## Notes
- `release-please` owns versioning — no `VERSION`/`CHANGELOG` edits here.