### PR TITLE
fix(client): make the library settings page full width

### DIFF
--- a/client/src/routes/(app)/libraries/[id]/settings/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/settings/+page.svelte
@@ -414,7 +414,7 @@
 	});
 </script>
 
-<div class="min-h-0 w-full max-w-3xl flex-1 overflow-y-auto px-0.5">
+<div class="min-h-0 w-full flex-1 overflow-y-auto px-0.5">
 	<div class="divide-y divide-surface-200-800">
 		<!-- Library Name -->
 		<SettingsSection


### PR DESCRIPTION
## What

Removes the `max-w-3xl` cap on the library settings page root container so the content uses the full pane width, matching the other library sub-pages (Tags, Timeline, Objects, Feed, Map) which are already full width.

```diff
-<div class="min-h-0 w-full max-w-3xl flex-1 overflow-y-auto px-0.5">
+<div class="min-h-0 w-full flex-1 overflow-y-auto px-0.5">
```

Section *description* text still wraps at `max-w-prose` (set inside `SettingsSection.svelte`), so long descriptions stay readable.

## Verification

- `bun run typecheck` — 0 errors / 0 warnings
- `prettier --check` — clean
- Unit: 48/48 pass for the settings page (`page.svelte.test.ts`)
- E2E (chromium, real seeded stack): 12/12 pass, including the settings-page mobile-nav regression
- Visual: confirmed full-width, responsive layout at 1600px and 1024px viewports