### PR TITLE
refactor(client): UI consistency & polish pass (top-10 improvements)

### DIFF
--- a/client/src/lib/components/FilePreview.svelte
+++ b/client/src/lib/components/FilePreview.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, onDestroy } from 'svelte';
+	import { onMount, onDestroy, tick } from 'svelte';
 	import { ICONS } from '$lib/utils/icons';
 	import { getMimeIcon } from '$lib/utils/mime-icons';
 	import { proxyQueryString, resolveVariant } from '$lib/shared/image-variants';
@@ -327,6 +327,23 @@
 			});
 	});
 
+	// Focus management: the lightbox is a hand-rolled dialog (not Skeleton's
+	// `Dialog`), so move focus into it on open and restore the trigger on close —
+	// otherwise keyboard/AT users are dropped back at the top of the page.
+	let dialogEl = $state<HTMLDivElement | null>(null);
+	let previouslyFocused: HTMLElement | null = null;
+
+	$effect(() => {
+		if (open) {
+			previouslyFocused = (document.activeElement as HTMLElement) ?? null;
+			// dialogEl mounts during this render pass; focus once it exists.
+			void tick().then(() => dialogEl?.focus());
+		} else if (previouslyFocused) {
+			previouslyFocused.focus();
+			previouslyFocused = null;
+		}
+	});
+
 	// Keyboard navigation
 	function handleKeydown(event: KeyboardEvent) {
 		if (!open) return;
@@ -339,6 +356,28 @@
 		} else if (event.key === 'Escape') {
 			event.preventDefault();
 			closePreview();
+		} else if (event.key === 'Tab' && dialogEl) {
+			// Trap Tab within the dialog.
+			const focusables = [
+				...dialogEl.querySelectorAll<HTMLElement>(
+					'a[href], button:not([disabled]), input, select, textarea, video, [tabindex]:not([tabindex="-1"])'
+				)
+			].filter((el) => el.offsetParent !== null || el === dialogEl);
+			if (focusables.length === 0) {
+				event.preventDefault();
+				dialogEl.focus();
+				return;
+			}
+			const first = focusables[0];
+			const last = focusables[focusables.length - 1];
+			const active = document.activeElement as HTMLElement;
+			if (event.shiftKey && (active === first || active === dialogEl)) {
+				event.preventDefault();
+				last.focus();
+			} else if (!event.shiftKey && active === last) {
+				event.preventDefault();
+				first.focus();
+			}
 		}
 	}
 
@@ -357,8 +396,11 @@
 </script>
 
 {#if open}
+	<!-- Backdrop click closes; keyboard (Esc/arrows/Tab-trap) is handled globally in handleKeydown. -->
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<div
-		class="fixed inset-0 z-[60] flex items-center justify-center bg-black/95 backdrop-blur-sm"
+		bind:this={dialogEl}
+		class="fixed inset-0 z-[60] flex items-center justify-center bg-black/95 backdrop-blur-sm focus:outline-none"
 		role="dialog"
 		aria-modal="true"
 		aria-label={file.name}
@@ -366,7 +408,6 @@
 		onclick={(e) => {
 			if (e.target === e.currentTarget) closePreview();
 		}}
-		onkeydown={() => {}}
 	>
 		<!-- Media content: fills the entire viewport -->
 		{#if previewType === 'video'}

--- a/client/src/lib/components/SidebarLibraryNav.svelte
+++ b/client/src/lib/components/SidebarLibraryNav.svelte
@@ -19,6 +19,8 @@
 		user: AuthUser | null;
 		/** Current route path, e.g. `/libraries/abc/timeline`. */
 		currentPath?: string;
+		/** The shell's libraries fetch failed (distinct from "no libraries"). */
+		librariesError?: boolean;
 		oncreate?: () => void;
 	}
 
@@ -30,7 +32,7 @@
 		active: boolean;
 	}
 
-	let { libraries, user, currentPath = '', oncreate }: Props = $props();
+	let { libraries, user, currentPath = '', librariesError = false, oncreate }: Props = $props();
 
 	function libBase(id: string): string {
 		return `/libraries/${id}`;
@@ -174,6 +176,15 @@
 	</div>
 
 	<hr class="my-2 border-surface-200-800" />
+
+	{#if librariesError && !currentLibrary}
+		<div
+			class="mx-2 mb-2 flex items-start gap-2 rounded-lg border border-error-500/30 bg-error-500/10 px-3 py-2 text-xs text-error-600"
+		>
+			<AppIcon name={ICONS.warning} class="size-4 shrink-0" />
+			<span>Couldn't load your libraries. Refresh to try again.</span>
+		</div>
+	{/if}
 
 	<div class="flex-1 overflow-y-auto px-2">
 		<nav aria-label="Library sections" class="flex w-full flex-col gap-1">

--- a/client/src/lib/components/SidebarLibraryNav.svelte.test.ts
+++ b/client/src/lib/components/SidebarLibraryNav.svelte.test.ts
@@ -156,6 +156,19 @@ describe('SidebarLibraryNav', () => {
 		expect(labels).toContain('Admin');
 	});
 
+	it('shows a load-error notice (distinct from "no libraries") when librariesError is set', () => {
+		const failed = render(SidebarLibraryNav, {
+			props: { libraries: [], user: owner, librariesError: true }
+		});
+		expect(failed.container.textContent).toContain("Couldn't load your libraries");
+
+		// A genuinely-empty (but successful) load shows no error notice.
+		const empty = render(SidebarLibraryNav, {
+			props: { libraries: [], user: owner }
+		});
+		expect(empty.container.textContent).not.toContain("Couldn't load your libraries");
+	});
+
 	it('re-emits create from the switcher via oncreate', async () => {
 		const oncreate = vi.fn();
 		const screen = render(SidebarLibraryNav, {

--- a/client/src/lib/components/UploadModal.svelte
+++ b/client/src/lib/components/UploadModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import AppModal from '$lib/components/ui/AppModal.svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { ICONS } from '$lib/utils/icons';
 	import { uploadQueue } from '$lib/state/upload-queue.svelte';
 
@@ -66,14 +67,11 @@
 
 	<div class="flex justify-end gap-2">
 		<button type="button" class="btn preset-tonal" onclick={() => (open = false)}>Cancel</button>
-		<button
-			type="button"
-			class="btn preset-filled-primary-500"
-			disabled={!selectedFileCount}
-			onclick={handleUpload}
-		>
-			<AppIcon name={ICONS.upload} class="size-4" />
+		<Button disabled={!selectedFileCount} onclick={handleUpload}>
+			{#snippet icon()}
+				<AppIcon name={ICONS.upload} class="size-4" />
+			{/snippet}
 			<span>Upload</span>
-		</button>
+		</Button>
 	</div>
 </AppModal>

--- a/client/src/lib/components/UploadProgress.svelte
+++ b/client/src/lib/components/UploadProgress.svelte
@@ -3,6 +3,7 @@
 	import { formatFileSize } from '$lib/utils/mime-icons';
 	import { uploadQueue } from '$lib/state/upload-queue.svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 
 	let expanded = $state(true);
 </script>
@@ -39,13 +40,9 @@
 					>
 						Retry All
 					</button>
-					<button
-						type="button"
-						class="btn preset-tonal-error btn-sm"
-						onclick={() => uploadQueue.clearErrors()}
-					>
+					<Button variant="tonal" color="error" size="sm" onclick={() => uploadQueue.clearErrors()}>
 						Clear
-					</button>
+					</Button>
 				</div>
 			</div>
 		{/if}
@@ -86,13 +83,14 @@
 									>
 										Retry
 									</button>
-									<button
-										type="button"
-										class="btn preset-tonal-error btn-sm"
+									<Button
+										variant="tonal"
+										color="error"
+										size="sm"
 										onclick={() => uploadQueue.removeFile(item.id)}
 									>
 										Remove
-									</button>
+									</Button>
 								</div>
 							</div>
 						{:else if item.status === 'done'}

--- a/client/src/lib/components/admin/AdminJobsPanel.svelte
+++ b/client/src/lib/components/admin/AdminJobsPanel.svelte
@@ -36,6 +36,9 @@
 	import { toast } from '$lib/state/toast';
 	import { ICONS } from '$lib/utils/icons';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import AppPanel from '$lib/components/ui/AppPanel.svelte';
+	import StatCard from '$lib/components/ui/StatCard.svelte';
+	import ConfirmModal from '$lib/components/ui/ConfirmModal.svelte';
 
 	interface Props {
 		embedded?: boolean;
@@ -50,6 +53,8 @@
 	let queueFilter = $state('all');
 	let actionJobId = $state<string | null>(null);
 	let actionQueueName = $state<string | null>(null);
+	let purgeTarget = $state<string | null>(null);
+	let purgeModalOpen = $state(false);
 	let expandedJobId = $state<string | null>(null);
 
 	const statusOptions = [
@@ -200,17 +205,22 @@
 		}
 	}
 
-	async function purgeQueue(queueName: string) {
+	function purgeQueue(queueName: string) {
+		purgeTarget = queueName;
+		purgeModalOpen = true;
+	}
+
+	async function confirmPurgeQueue() {
+		const queueName = purgeTarget;
+		if (!queueName) return;
 		const target = formatQueueName(queueName);
-		const confirmed = window.confirm(
-			`Purge jobs in queue "${target}"? This removes waiting, delayed, failed, and completed jobs.`
-		);
-		if (!confirmed) return;
 
 		actionQueueName = queueName;
 		try {
 			const result = await api.admin.purgeQueue(queueName);
 			toast.add({ title: `Purged ${result.total} jobs from ${target}`, color: 'success' });
+			purgeModalOpen = false;
+			purgeTarget = null;
 		} catch {
 			toast.add({ title: 'Failed to purge queue', color: 'error' });
 		} finally {
@@ -230,19 +240,30 @@
 		label: string;
 		value: number;
 		icon: string;
-		color: string;
+		iconClass: string;
 	}
 
+	const NEUTRAL_TILE = 'text-surface-500 bg-surface-500/10';
 	const statTiles = $derived<StatTile[]>([
-		{ label: 'Active', value: totalActive, icon: ICONS.stateActive, color: 'text-primary-500' },
-		{ label: 'Waiting', value: totalWaiting, icon: ICONS.stateWaiting, color: '' },
+		{
+			label: 'Active',
+			value: totalActive,
+			icon: ICONS.stateActive,
+			iconClass: 'text-primary-500 bg-primary-500/10'
+		},
+		{ label: 'Waiting', value: totalWaiting, icon: ICONS.stateWaiting, iconClass: NEUTRAL_TILE },
 		{
 			label: 'Failed',
 			value: totalFailed,
 			icon: ICONS.stateFailed,
-			color: totalFailed > 0 ? 'text-error-500' : ''
+			iconClass: totalFailed > 0 ? 'text-error-500 bg-error-500/10' : NEUTRAL_TILE
 		},
-		{ label: 'Delayed', value: totalDelayed, icon: ICONS.stateDelayed, color: 'text-warning-500' }
+		{
+			label: 'Delayed',
+			value: totalDelayed,
+			icon: ICONS.stateDelayed,
+			iconClass: 'text-warning-500 bg-warning-500/10'
+		}
 	]);
 </script>
 
@@ -264,20 +285,12 @@
 
 	<div class="grid grid-cols-2 gap-3 md:grid-cols-4">
 		{#each statTiles as tile (tile.label)}
-			<div class="card preset-filled-surface-100-900 p-4">
-				<div class="flex items-center justify-between gap-3">
-					<div>
-						<p class="text-xs tracking-wide text-surface-500 uppercase">{tile.label}</p>
-						<p class={['mt-1 text-3xl font-bold', tile.color]}>{tile.value}</p>
-					</div>
-					<AppIcon name={tile.icon} class={['size-6', tile.color].join(' ')} />
-				</div>
-			</div>
+			<StatCard title={tile.label} value={tile.value} icon={tile.icon} iconClass={tile.iconClass} />
 		{/each}
 	</div>
 
 	{#if queues.length}
-		<div class="max-h-[24rem] overflow-auto card preset-filled-surface-100-900">
+		<AppPanel title="Queues" icon={ICONS.jobDefault} flush bodyClass="max-h-[24rem] overflow-auto">
 			<table class="w-full text-sm">
 				<thead class="bg-surface-200-800">
 					<tr class="text-left">
@@ -333,27 +346,26 @@
 					{/each}
 				</tbody>
 			</table>
-		</div>
+		</AppPanel>
 	{/if}
 
-	<div class="overflow-hidden card preset-filled-surface-100-900">
-		<div class="flex flex-wrap items-center gap-3 border-b border-surface-200-800 p-4">
-			<h3 class="flex-1 text-lg font-semibold">Jobs</h3>
-			<select class="select w-40" bind:value={queueFilter}>
+	<AppPanel title="Jobs" icon={ICONS.jobDefault} flush>
+		{#snippet actions()}
+			<select class="select w-36 sm:w-40" aria-label="Filter by queue" bind:value={queueFilter}>
 				{#each queueOptions as opt (opt.value)}
 					<option value={opt.value}>{opt.label}</option>
 				{/each}
 			</select>
-			<select class="select w-36" bind:value={statusFilter}>
+			<select class="select w-32 sm:w-36" aria-label="Filter by status" bind:value={statusFilter}>
 				{#each statusOptions as opt (opt.value)}
 					<option value={opt.value}>{opt.label}</option>
 				{/each}
 			</select>
-			<span class="badge preset-tonal-surface">
+			<span class="badge preset-tonal-surface whitespace-nowrap">
 				{filteredJobs.length}
 				{filteredJobs.length === 1 ? 'job' : 'jobs'}
 			</span>
-		</div>
+		{/snippet}
 
 		<div class="max-h-[40rem] overflow-auto">
 			{#if !connected && jobs.length === 0}
@@ -481,5 +493,18 @@
 				</div>
 			{/if}
 		</div>
-	</div>
+	</AppPanel>
+
+	<ConfirmModal
+		bind:open={purgeModalOpen}
+		title="Purge queue?"
+		message={purgeTarget
+			? `Purge jobs in queue "${formatQueueName(purgeTarget)}"? This removes waiting, delayed, failed, and completed jobs.`
+			: ''}
+		confirmLabel="Purge"
+		confirmClass="error"
+		confirmIcon={ICONS.trash}
+		pending={actionQueueName !== null}
+		onconfirm={confirmPurgeQueue}
+	/>
 </div>

--- a/client/src/lib/components/admin/AdminJobsPanel.svelte.test.ts
+++ b/client/src/lib/components/admin/AdminJobsPanel.svelte.test.ts
@@ -130,7 +130,9 @@ describe('AdminJobsPanel', () => {
 		const { screen } = renderPanel();
 		const h1 = screen.container.querySelector('h1');
 		expect(h1?.textContent?.trim()).toBe('Background Jobs');
-		expect(screen.container.querySelector('h2')).toBeNull();
+		// Panel titles (e.g. "Jobs") are h2; the section heading itself must not be one.
+		const h2Text = [...screen.container.querySelectorAll('h2')].map((h) => h.textContent?.trim());
+		expect(h2Text).not.toContain('Background Jobs');
 	});
 
 	it('renders heading as h2 when embedded', async () => {
@@ -280,35 +282,46 @@ describe('AdminJobsPanel', () => {
 		expect(spinner).not.toBeNull();
 	});
 
-	it('calls the purge API after confirmation', async () => {
+	it('calls the purge API after confirming in the modal', async () => {
 		vi.stubGlobal('EventSource', MockEventSource);
-		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
 		const { screen, es } = renderPanel();
 		es.simulateMessage(getSnapshot());
 		await tick();
-		const purgeBtn = [...screen.container.querySelectorAll('button')].find((b) =>
+		// The queue-row button opens the confirm modal rather than purging directly.
+		const rowPurge = [...screen.container.querySelectorAll('button')].find((b) =>
 			b.textContent?.includes('Purge')
 		) as HTMLButtonElement;
-		expect(purgeBtn).toBeDefined();
-		purgeBtn.click();
-		await tick();
-		expect(mocks.purgeQueue).toHaveBeenCalledWith('{video-processing}');
-		confirmSpy.mockRestore();
-	});
-
-	it('does not purge when confirmation is cancelled', async () => {
-		vi.stubGlobal('EventSource', MockEventSource);
-		const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
-		const { screen, es } = renderPanel();
-		es.simulateMessage(getSnapshot());
-		await tick();
-		const purgeBtn = [...screen.container.querySelectorAll('button')].find((b) =>
-			b.textContent?.includes('Purge')
-		) as HTMLButtonElement;
-		purgeBtn.click();
+		expect(rowPurge).toBeDefined();
+		rowPurge.click();
 		await tick();
 		expect(mocks.purgeQueue).not.toHaveBeenCalled();
-		confirmSpy.mockRestore();
+		// Confirm in the modal (rendered in a portal on document.body).
+		const confirmBtn = [...document.querySelectorAll('button.preset-filled-error-500')].find((b) =>
+			b.textContent?.includes('Purge')
+		) as HTMLButtonElement;
+		expect(confirmBtn).toBeDefined();
+		confirmBtn.click();
+		await tick();
+		expect(mocks.purgeQueue).toHaveBeenCalledWith('{video-processing}');
+	});
+
+	it('does not purge when the modal is cancelled', async () => {
+		vi.stubGlobal('EventSource', MockEventSource);
+		const { screen, es } = renderPanel();
+		es.simulateMessage(getSnapshot());
+		await tick();
+		const rowPurge = [...screen.container.querySelectorAll('button')].find((b) =>
+			b.textContent?.includes('Purge')
+		) as HTMLButtonElement;
+		rowPurge.click();
+		await tick();
+		const cancelBtn = [...document.querySelectorAll('button')].find(
+			(b) => b.textContent?.trim() === 'Cancel'
+		) as HTMLButtonElement;
+		expect(cancelBtn).toBeDefined();
+		cancelBtn.click();
+		await tick();
+		expect(mocks.purgeQueue).not.toHaveBeenCalled();
 	});
 
 	it('closes the EventSource on unmount', async () => {

--- a/client/src/lib/components/editor/EditorHeader.svelte
+++ b/client/src/lib/components/editor/EditorHeader.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { ICONS } from '$lib/utils/icons';
 	import type { LibraryFile } from '$lib/types/api';
 	import type { JobButtonColor, JobStatusButton } from '$lib/utils/job-status-button';
+
+	type ButtonColor = 'primary' | 'surface' | 'error' | 'warning' | 'success';
+	type ButtonVariant = 'filled' | 'tonal';
 
 	interface Props {
 		file: LibraryFile | null | undefined;
@@ -38,9 +42,9 @@
 		return !!mimeType && (mimeType.startsWith('video/') || mimeType.startsWith('audio/'));
 	}
 
-	// JobButtonColor -> Skeleton color token. `neutral` has no preset of its own;
+	// JobButtonColor -> Button color token. `neutral` has no preset of its own;
 	// it maps onto the surface palette.
-	const colorToken: Record<JobButtonColor, string> = {
+	const colorToken: Record<JobButtonColor, ButtonColor> = {
 		primary: 'primary',
 		neutral: 'surface',
 		warning: 'warning',
@@ -48,10 +52,10 @@
 	};
 
 	// The Vue original used `solid` (filled) for a failed job and `soft` (tonal)
-	// otherwise. Mirror that here with Skeleton presets.
-	function actionPreset(btn: JobStatusButton, failed: boolean): string {
-		const token = colorToken[btn.color];
-		return failed ? `preset-filled-${token}-500` : `preset-tonal-${token}`;
+	// otherwise. Mirror that here: filled when failed, tonal otherwise. The Button
+	// renders the same `preset-filled-{color}-500` / `preset-tonal-{color}` tokens.
+	function actionVariant(failed: boolean): ButtonVariant {
+		return failed ? 'filled' : 'tonal';
 	}
 
 	const playable = $derived(!!file && isPlayable(file.mimeType));
@@ -65,60 +69,62 @@
 </script>
 
 <div class="flex w-full items-center gap-3">
-	<button type="button" class="btn preset-tonal-surface btn-sm" onclick={() => onback?.()}>
-		<AppIcon name={ICONS.back} class="size-4" />
+	<Button variant="tonal" color="surface" size="sm" onclick={() => onback?.()}>
+		{#snippet icon()}
+			<AppIcon name={ICONS.back} class="size-4" />
+		{/snippet}
 		Back
-	</button>
+	</Button>
 
 	<div class="min-w-0 flex-1">
 		<p class="truncate text-lg font-semibold">{file?.name ?? 'Loading…'}</p>
 	</div>
 
 	{#if playable}
-		<button
-			type="button"
-			class="btn btn-sm {actionPreset(transcribeButton, transcribeFailed)}"
+		<Button
+			size="sm"
+			variant={actionVariant(transcribeFailed)}
+			color={colorToken[transcribeButton.color]}
+			loading={transcribeLoading}
 			disabled={transcribeButton.disabled || transcribing}
 			onclick={() => ontranscribe?.()}
 		>
-			{#if transcribeLoading}
-				<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-			{:else}
+			{#snippet icon()}
 				<AppIcon name={ICONS.transcript} class="size-4" />
-			{/if}
+			{/snippet}
 			{transcribeButton.label}
-		</button>
+		</Button>
 	{/if}
 
 	{#if canDetectAudio}
-		<button
-			type="button"
-			class="btn btn-sm {actionPreset(audioDetectButton, audioDetectFailed)}"
+		<Button
+			size="sm"
+			variant={actionVariant(audioDetectFailed)}
+			color={colorToken[audioDetectButton.color]}
+			loading={audioDetectLoading}
 			disabled={audioDetectButton.disabled || audioDetecting}
 			onclick={() => onaudioDetect?.()}
 		>
-			{#if audioDetectLoading}
-				<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-			{:else}
+			{#snippet icon()}
 				<AppIcon name={ICONS.audioDetect} class="size-4" />
-			{/if}
+			{/snippet}
 			{audioDetectButton.label}
-		</button>
+		</Button>
 	{/if}
 
 	{#if playable}
-		<button
-			type="button"
-			class="btn btn-sm {actionPreset(waveformButton, waveformFailed)}"
+		<Button
+			size="sm"
+			variant={actionVariant(waveformFailed)}
+			color={colorToken[waveformButton.color]}
+			loading={waveformLoading}
 			disabled={waveformButton.disabled || waveformGenerating}
 			onclick={() => onwaveform?.()}
 		>
-			{#if waveformLoading}
-				<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-			{:else}
+			{#snippet icon()}
 				<AppIcon name={ICONS.waveform} class="size-4" />
-			{/if}
+			{/snippet}
 			{waveformButton.label}
-		</button>
+		</Button>
 	{/if}
 </div>

--- a/client/src/lib/components/editor/HighlightFiltersPanel.svelte
+++ b/client/src/lib/components/editor/HighlightFiltersPanel.svelte
@@ -8,6 +8,7 @@
 	 * `onseek` so the player can jump to that moment.
 	 */
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { ICONS } from '$lib/utils/icons';
 	import type {
 		HighlightFilter,
@@ -166,23 +167,25 @@
 			{#if !collapsed}
 				<div class="flex shrink-0 items-center gap-1">
 					{#if filters.length === 0}
-						<button
-							type="button"
-							class="btn preset-tonal-primary btn-sm"
-							disabled={loading}
+						<Button
+							variant="tonal"
+							color="primary"
+							size="sm"
+							{loading}
 							onclick={() => onloadpresets?.()}
 						>
-							<AppIcon
-								name={loading ? ICONS.loading : ICONS.loadPresets}
-								class={loading ? 'size-4 animate-spin' : 'size-4'}
-							/>
+							{#snippet icon()}
+								<AppIcon name={ICONS.loadPresets} class="size-4" />
+							{/snippet}
 							Load presets
-						</button>
+						</Button>
 					{/if}
-					<button type="button" class="btn preset-filled-primary-500 btn-sm" onclick={startAdd}>
-						<AppIcon name={ICONS.plus} class="size-4" />
+					<Button size="sm" onclick={startAdd}>
+						{#snippet icon()}
+							<AppIcon name={ICONS.plus} class="size-4" />
+						{/snippet}
 						Add filter
-					</button>
+					</Button>
 				</div>
 			{/if}
 		</div>
@@ -240,17 +243,13 @@
 							/>
 						</div>
 						<div class="flex items-center gap-1">
-							<button type="button" class="btn preset-tonal-surface btn-sm" onclick={cancelAdd}>
-								Cancel
-							</button>
-							<button
-								type="button"
-								class="btn preset-filled-primary-500 btn-sm"
-								onclick={submitAdd}
-							>
-								<AppIcon name={ICONS.check} class="size-4" />
+							<Button variant="tonal" color="surface" size="sm" onclick={cancelAdd}>Cancel</Button>
+							<Button size="sm" onclick={submitAdd}>
+								{#snippet icon()}
+									<AppIcon name={ICONS.check} class="size-4" />
+								{/snippet}
 								Save
-							</button>
+							</Button>
 						</div>
 					</div>
 				</div>
@@ -301,21 +300,15 @@
 										/>
 									</div>
 									<div class="flex items-center gap-1">
-										<button
-											type="button"
-											class="btn preset-tonal-surface btn-sm"
-											onclick={cancelEdit}
-										>
+										<Button variant="tonal" color="surface" size="sm" onclick={cancelEdit}>
 											Cancel
-										</button>
-										<button
-											type="button"
-											class="btn preset-filled-primary-500 btn-sm"
-											onclick={() => submitEdit(f.id)}
-										>
-											<AppIcon name={ICONS.check} class="size-4" />
+										</Button>
+										<Button size="sm" onclick={() => submitEdit(f.id)}>
+											{#snippet icon()}
+												<AppIcon name={ICONS.check} class="size-4" />
+											{/snippet}
 											Save
-										</button>
+										</Button>
 									</div>
 								</div>
 							{:else}
@@ -362,22 +355,30 @@
 												{((aggregates[f.id]?.maxScore ?? 0) * 100).toFixed(0)}%
 											</span>
 										{/if}
-										<button
-											type="button"
-											class="btn-icon btn-icon-sm preset-tonal-surface"
+										<Button
+											iconOnly
+											size="sm"
+											variant="tonal"
+											color="surface"
 											aria-label="Edit filter"
 											onclick={() => startEdit(f)}
 										>
-											<AppIcon name={ICONS.edit} class="size-4" />
-										</button>
-										<button
-											type="button"
-											class="btn-icon btn-icon-sm preset-tonal-error"
+											{#snippet icon()}
+												<AppIcon name={ICONS.edit} class="size-4" />
+											{/snippet}
+										</Button>
+										<Button
+											iconOnly
+											size="sm"
+											variant="tonal"
+											color="error"
 											aria-label="Remove filter"
 											onclick={() => onremove?.(f.id)}
 										>
-											<AppIcon name={ICONS.trash} class="size-4" />
-										</button>
+											{#snippet icon()}
+												<AppIcon name={ICONS.trash} class="size-4" />
+											{/snippet}
+										</Button>
 									</div>
 								</div>
 

--- a/client/src/lib/components/editor/MomentEditForm.svelte
+++ b/client/src/lib/components/editor/MomentEditForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { ICONS } from '$lib/utils/icons';
 	import type { Moment } from '$lib/types/api';
 
@@ -79,49 +80,60 @@
 		<div class="flex items-center justify-between gap-2 border-b border-surface-200-800 p-3">
 			<p class="text-sm font-semibold">Edit moment</p>
 			<div class="flex items-center gap-1">
-				<button
-					type="button"
-					class="btn preset-tonal-primary btn-sm"
+				<Button
+					variant="tonal"
+					color="primary"
+					size="sm"
 					disabled={reprocessDisabled}
 					title="Reprocess"
 					onclick={() => onexport?.(moment.id)}
 				>
-					<AppIcon name={ICONS.reload} class="size-4" />
+					{#snippet icon()}
+						<AppIcon name={ICONS.reload} class="size-4" />
+					{/snippet}
 					Reprocess
-				</button>
+				</Button>
 
-				<button
-					type="button"
-					class="btn-icon btn-icon-sm preset-tonal-surface"
+				<Button
+					iconOnly
+					size="sm"
+					variant="tonal"
+					color="surface"
 					title="Download"
-					disabled={downloadPending}
+					loading={downloadPending}
 					onclick={() => ondownload?.(moment.id)}
 				>
-					{#if downloadPending}
-						<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-					{:else}
+					{#snippet icon()}
 						<AppIcon name={ICONS.download} class="size-4" />
-					{/if}
-				</button>
+					{/snippet}
+				</Button>
 
-				<button
-					type="button"
-					class="btn-icon btn-icon-sm preset-tonal-surface"
+				<Button
+					iconOnly
+					size="sm"
+					variant="tonal"
+					color="surface"
 					title="Share"
 					onclick={() => onshare?.(moment.id)}
 				>
-					<AppIcon name={ICONS.share} class="size-4" />
-				</button>
+					{#snippet icon()}
+						<AppIcon name={ICONS.share} class="size-4" />
+					{/snippet}
+				</Button>
 
-				<button
-					type="button"
-					class="btn-icon btn-icon-sm preset-tonal-surface"
+				<Button
+					iconOnly
+					size="sm"
+					variant="tonal"
+					color="surface"
 					aria-label="Close"
 					title="Close"
 					onclick={() => onclose?.()}
 				>
-					<AppIcon name={ICONS.close} class="size-4" />
-				</button>
+					{#snippet icon()}
+						<AppIcon name={ICONS.close} class="size-4" />
+					{/snippet}
+				</Button>
 			</div>
 		</div>
 
@@ -169,14 +181,18 @@
 						max={duration}
 						bind:value={startSeconds}
 					/>
-					<button
-						type="button"
-						class="btn-icon btn-icon-sm preset-tonal-primary"
+					<Button
+						iconOnly
+						size="sm"
+						variant="tonal"
+						color="primary"
 						title="Set to playhead"
 						onclick={() => onsetToPlayhead?.('start')}
 					>
-						<AppIcon name={ICONS.snapToPlayhead} class="size-4" />
-					</button>
+						{#snippet icon()}
+							<AppIcon name={ICONS.snapToPlayhead} class="size-4" />
+						{/snippet}
+					</Button>
 				</div>
 
 				<div class="flex min-w-[220px] flex-1 items-center gap-2">
@@ -192,28 +208,36 @@
 						max={duration}
 						bind:value={endSeconds}
 					/>
-					<button
-						type="button"
-						class="btn-icon btn-icon-sm preset-tonal-primary"
+					<Button
+						iconOnly
+						size="sm"
+						variant="tonal"
+						color="primary"
 						title="Set to playhead"
 						onclick={() => onsetToPlayhead?.('end')}
 					>
-						<AppIcon name={ICONS.snapToPlayhead} class="size-4" />
-					</button>
+						{#snippet icon()}
+							<AppIcon name={ICONS.snapToPlayhead} class="size-4" />
+						{/snippet}
+					</Button>
 				</div>
 			</div>
 		</div>
 
 		<!-- Footer -->
 		<div class="flex w-full items-center justify-end gap-2 border-t border-surface-200-800 p-3">
-			<button type="button" class="btn preset-tonal-error btn-sm" onclick={onDelete}>
-				<AppIcon name={ICONS.trash} class="size-4" />
+			<Button variant="tonal" color="error" size="sm" onclick={onDelete}>
+				{#snippet icon()}
+					<AppIcon name={ICONS.trash} class="size-4" />
+				{/snippet}
 				Delete
-			</button>
-			<button type="button" class="btn preset-filled-primary-500 btn-sm" onclick={onSave}>
-				<AppIcon name={ICONS.save} class="size-4" />
+			</Button>
+			<Button size="sm" onclick={onSave}>
+				{#snippet icon()}
+					<AppIcon name={ICONS.save} class="size-4" />
+				{/snippet}
 				Save
-			</button>
+			</Button>
 		</div>
 	</div>
 {/if}

--- a/client/src/lib/components/editor/MomentShareModal.svelte
+++ b/client/src/lib/components/editor/MomentShareModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import AppModal from '$lib/components/ui/AppModal.svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { ICONS } from '$lib/utils/icons';
 	import { api } from '$lib/api';
 	import { toast } from '$lib/state/toast';
@@ -88,19 +89,17 @@
 
 <AppModal bind:open title="Share moment" {description}>
 	<div class="flex flex-col gap-3">
-		<button
-			type="button"
-			class="btn self-start preset-filled-primary-500"
+		<Button
+			class="self-start"
+			loading={creating}
 			disabled={!sharingEnabled || creating}
 			onclick={onCreate}
 		>
-			{#if creating}
-				<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-			{:else}
+			{#snippet icon()}
 				<AppIcon name={ICONS.link} class="size-4" />
-			{/if}
+			{/snippet}
 			<span>Create share link</span>
-		</button>
+		</Button>
 
 		{#if loading}
 			<div class="text-sm opacity-60">Loading…</div>
@@ -119,10 +118,12 @@
 						>
 							<AppIcon name={ICONS.copy} class="size-4" />
 						</button>
-						<button type="button" class="btn preset-tonal-error" onclick={() => onRevoke(s.token)}>
-							<AppIcon name={ICONS.close} class="size-4" />
+						<Button variant="tonal" color="error" onclick={() => onRevoke(s.token)}>
+							{#snippet icon()}
+								<AppIcon name={ICONS.close} class="size-4" />
+							{/snippet}
 							<span>Revoke</span>
-						</button>
+						</Button>
 					</div>
 				{/each}
 			</div>

--- a/client/src/lib/components/editor/MomentTimeline.svelte
+++ b/client/src/lib/components/editor/MomentTimeline.svelte
@@ -2,6 +2,7 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { browser } from '$app/environment';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { ICONS } from '$lib/utils/icons';
 	import type { Moment } from '$lib/types/api';
 	import { createWaveformRenderer } from '$lib/state/waveform-renderer';
@@ -484,37 +485,39 @@
 		</span>
 		<span class="text-xs text-surface-500 tabular-nums">{(zoom * 100).toFixed(0)}%</span>
 		<div class="flex-1"></div>
-		<button
-			type="button"
-			class="btn-icon btn-icon-sm preset-tonal-surface"
+		<Button
+			iconOnly
+			size="sm"
+			variant="tonal"
+			color="surface"
 			title="Keyboard shortcuts"
 			aria-label="Keyboard shortcuts"
 			data-icon={ICONS.keyboard}
 			onclick={() => onopenShortcuts?.()}
 		>
-			<AppIcon name={ICONS.keyboard} class="size-4" />
-		</button>
-		<button
-			type="button"
-			class="btn preset-filled-primary-500 btn-sm"
-			onclick={() => oncreateMoment?.()}
-		>
-			<AppIcon name={ICONS.plus} class="size-4" />
+			{#snippet icon()}
+				<AppIcon name={ICONS.keyboard} class="size-4" />
+			{/snippet}
+		</Button>
+		<Button size="sm" onclick={() => oncreateMoment?.()}>
+			{#snippet icon()}
+				<AppIcon name={ICONS.plus} class="size-4" />
+			{/snippet}
 			New moment
-		</button>
-		<button
-			type="button"
-			class="btn btn-sm {hasPending ? 'preset-filled-warning-500' : 'preset-tonal-surface'}"
+		</Button>
+		<Button
+			size="sm"
+			variant={hasPending ? 'filled' : 'tonal'}
+			color={hasPending ? 'warning' : 'surface'}
+			loading={savingPending}
 			disabled={!hasPending || savingPending}
 			onclick={savePending}
 		>
-			{#if savingPending}
-				<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-			{:else}
+			{#snippet icon()}
 				<AppIcon name={ICONS.save} class="size-4" />
-			{/if}
+			{/snippet}
 			Save changes
-		</button>
+		</Button>
 	</div>
 
 	<div bind:this={scrollEl} class="timeline-scroll overflow-x-scroll overflow-y-hidden">

--- a/client/src/lib/components/library/LibraryEmptyState.svelte
+++ b/client/src/lib/components/library/LibraryEmptyState.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ICONS } from '$lib/utils/icons';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 
 	interface Props {
 		showTrashed: boolean;
@@ -27,10 +28,12 @@
 				<AppIcon name={ICONS.folder} class="size-4" />
 				<span>Create folder</span>
 			</button>
-			<button type="button" class="btn preset-tonal-primary" onclick={() => onuploadFiles?.()}>
-				<AppIcon name={ICONS.upload} class="size-4" />
+			<Button variant="tonal" color="primary" onclick={() => onuploadFiles?.()}>
+				{#snippet icon()}
+					<AppIcon name={ICONS.upload} class="size-4" />
+				{/snippet}
 				<span>Upload files</span>
-			</button>
+			</Button>
 		</div>
 	{/if}
 </div>

--- a/client/src/lib/components/library/LibraryEntriesTable.svelte
+++ b/client/src/lib/components/library/LibraryEntriesTable.svelte
@@ -88,8 +88,11 @@
 	<tbody class="divide-y divide-surface-200-800/60 select-none">
 		{#each entries as entry (`${entry.kind}-${entry.id}`)}
 			<tr
+				role="button"
+				tabindex="0"
 				class={[
 					'cursor-pointer transition-colors',
+					'focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none focus-visible:ring-inset',
 					isEntrySelected(entry)
 						? 'bg-primary-500/20 hover:bg-primary-500/30'
 						: 'hover:bg-primary-500/10',
@@ -106,6 +109,12 @@
 				]}
 				draggable={dragEnabled && !isRenaming(entry)}
 				onclick={(e) => onrowClick?.(entry, e)}
+				onkeydown={(e) => {
+					if (!isRenaming(entry) && (e.key === 'Enter' || e.key === ' ')) {
+						e.preventDefault();
+						onrowClick?.(entry, e as unknown as MouseEvent);
+					}
+				}}
 				ondblclick={() => onrowDoubleClick?.(entry)}
 				oncontextmenu={(e) => onrowContextMenu?.(entry, e)}
 				ondragstart={(e) => ondragStart?.(entry, e)}

--- a/client/src/lib/components/library/LibraryEntryCard.svelte
+++ b/client/src/lib/components/library/LibraryEntryCard.svelte
@@ -92,6 +92,7 @@
 	tabindex="0"
 	class={[
 		'cursor-pointer overflow-hidden rounded-md transition-colors select-none',
+		'focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none',
 		selected
 			? 'bg-primary-500/20 hover:bg-primary-500/30'
 			: 'bg-surface-100-900 hover:bg-primary-500/10',

--- a/client/src/lib/components/library/TagColorPickerDropdown.svelte
+++ b/client/src/lib/components/library/TagColorPickerDropdown.svelte
@@ -45,7 +45,7 @@
 	</button>
 	{#if open}
 		<div
-			class="absolute top-full left-0 z-20 mt-2 w-52 card rounded-xl border border-surface-200-800 preset-filled-surface-50-950 p-4 shadow-lg"
+			class="absolute top-full left-0 z-20 mt-2 w-52 card rounded-lg border border-surface-200-800 preset-filled-surface-100-900 p-4 shadow-xl"
 		>
 			<div class="grid grid-cols-4 gap-2">
 				{#each palette as entry (`${keyId}-${entry}`)}

--- a/client/src/lib/components/notifications/NotificationItem.svelte
+++ b/client/src/lib/components/notifications/NotificationItem.svelte
@@ -42,7 +42,7 @@
 <svelte:element
 	this={formatted.href ? 'a' : 'div'}
 	href={formatted.href ?? undefined}
-	class="group flex cursor-pointer items-start gap-3 px-3 py-2.5 transition-colors hover:bg-surface-100-900"
+	class="group flex cursor-pointer items-start gap-3 px-3 py-2.5 transition-colors hover:bg-surface-100-900 focus-visible:bg-surface-100-900 focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none focus-visible:ring-inset"
 	onclick={onClick}
 	role={formatted.href ? undefined : 'button'}
 	tabindex={formatted.href ? undefined : 0}

--- a/client/src/lib/components/profile/AccessTokensSection.svelte
+++ b/client/src/lib/components/profile/AccessTokensSection.svelte
@@ -3,6 +3,7 @@
 	import AppPanel from '$lib/components/ui/AppPanel.svelte';
 	import AppModal from '$lib/components/ui/AppModal.svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { ICONS } from '$lib/utils/icons';
 	import { api } from '$lib/api';
 	import { toast } from '$lib/state/toast';
@@ -138,19 +139,12 @@
 					{/each}
 				</select>
 			</label>
-			<button
-				type="button"
-				class="btn preset-filled-primary-500"
-				disabled={creating}
-				onclick={createToken}
-			>
-				{#if creating}
-					<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-				{:else}
+			<Button loading={creating} disabled={creating} onclick={createToken}>
+				{#snippet icon()}
 					<AppIcon name={ICONS.plus} class="size-4" />
-				{/if}
+				{/snippet}
 				Create token
-			</button>
+			</Button>
 		</div>
 
 		<hr class="border-surface-200-800" />
@@ -183,19 +177,19 @@
 								</div>
 							</div>
 						</div>
-						<button
-							type="button"
-							class="btn preset-tonal-error btn-sm"
+						<Button
+							variant="tonal"
+							color="error"
+							size="sm"
+							loading={revokingId === token.id}
 							disabled={revokingId === token.id}
 							onclick={() => revokeToken(token.id)}
 						>
-							{#if revokingId === token.id}
-								<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-							{:else}
+							{#snippet icon()}
 								<AppIcon name={ICONS.trash} class="size-4" />
-							{/if}
+							{/snippet}
 							Revoke
-						</button>
+						</Button>
 					</div>
 				{/each}
 			</div>
@@ -222,14 +216,18 @@
 	<div class="space-y-4">
 		<div class="flex items-center gap-2">
 			<input class="input w-full font-mono text-xs" value={createdToken?.token ?? ''} readonly />
-			<button
-				type="button"
-				class="btn-icon shrink-0 preset-tonal-surface"
+			<Button
+				iconOnly
+				variant="tonal"
+				color="surface"
+				class="shrink-0"
 				aria-label="Copy token"
 				onclick={copyToken}
 			>
-				<AppIcon name={ICONS.copy} class="size-4" />
-			</button>
+				{#snippet icon()}
+					<AppIcon name={ICONS.copy} class="size-4" />
+				{/snippet}
+			</Button>
 		</div>
 		<div class="flex items-start gap-3 card preset-tonal-warning p-4">
 			<AppIcon name={ICONS.shield} class="size-5 shrink-0 opacity-80" />
@@ -241,13 +239,7 @@
 			</div>
 		</div>
 		<div class="flex w-full justify-end">
-			<button
-				type="button"
-				class="btn preset-filled-primary-500"
-				onclick={() => (showCreated = false)}
-			>
-				Done
-			</button>
+			<Button onclick={() => (showCreated = false)}>Done</Button>
 		</div>
 	</div>
 </AppModal>

--- a/client/src/lib/components/ui/AppIcon.svelte
+++ b/client/src/lib/components/ui/AppIcon.svelte
@@ -25,6 +25,8 @@
 		class?: string;
 		width?: string | number;
 		height?: string | number;
+		/** Forwarded to the underlying icon (e.g. `aria-hidden`, `aria-label`). */
+		[key: string]: unknown;
 	}
 
 	let { name, size = 'md', class: klass = '', width, height, ...rest }: Props = $props();
@@ -36,4 +38,10 @@
 	const mergedClass = $derived([sizeClass, klass].filter(Boolean).join(' '));
 </script>
 
-<Icon icon={name} class={mergedClass} {width} {height} {...rest} />
+<!--
+	Icons are presentational by default — the accessible label lives on the
+	enclosing button/link. `aria-hidden="true"` keeps the glyph out of the a11y
+	tree (avoids double announcements); callers can override via `...rest`
+	(e.g. pass `aria-hidden={false}` / an `aria-label` for a standalone icon).
+-->
+<Icon icon={name} class={mergedClass} aria-hidden="true" {width} {height} {...rest} />

--- a/client/src/lib/components/ui/AppIcon.svelte.test.ts
+++ b/client/src/lib/components/ui/AppIcon.svelte.test.ts
@@ -37,4 +37,18 @@ describe('AppIcon', () => {
 		const cls = none.container.querySelector('svg')?.getAttribute('class') ?? '';
 		expect(cls).not.toContain('size-4');
 	});
+
+	it('is aria-hidden by default (decorative)', async () => {
+		const screen = render(AppIcon, { props: { name: ICONS.search } });
+		expect(screen.container.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+	});
+
+	it('lets callers override aria-hidden for a standalone labelled icon', async () => {
+		const screen = render(AppIcon, {
+			props: { name: ICONS.search, 'aria-hidden': false, 'aria-label': 'Search' }
+		});
+		const svg = screen.container.querySelector('svg');
+		expect(svg?.getAttribute('aria-hidden')).not.toBe('true');
+		expect(svg?.getAttribute('aria-label')).toBe('Search');
+	});
 });

--- a/client/src/lib/components/ui/AppModal.svelte
+++ b/client/src/lib/components/ui/AppModal.svelte
@@ -36,7 +36,9 @@
 						<Dialog.Title class="text-lg font-semibold">{title}</Dialog.Title>
 					{/if}
 					{#if description}
-						<Dialog.Description class="text-sm opacity-75">{description}</Dialog.Description>
+						<Dialog.Description class="text-sm text-surface-600-400"
+							>{description}</Dialog.Description
+						>
 					{/if}
 				</header>
 			{/if}

--- a/client/src/lib/components/ui/ConfirmModal.svelte
+++ b/client/src/lib/components/ui/ConfirmModal.svelte
@@ -48,7 +48,7 @@
 		>
 			<header class="flex flex-col gap-1">
 				<Dialog.Title class="text-lg font-semibold">{title}</Dialog.Title>
-				<Dialog.Description class="text-sm opacity-75">{message}</Dialog.Description>
+				<Dialog.Description class="text-sm text-surface-600-400">{message}</Dialog.Description>
 			</header>
 			<footer class="flex w-full justify-end gap-2">
 				<Button variant="tonal" color="surface" disabled={pending} onclick={() => (open = false)}>

--- a/client/src/lib/components/ui/ConfirmModal.svelte
+++ b/client/src/lib/components/ui/ConfirmModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Dialog } from '@skeletonlabs/skeleton-svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { ICONS } from '$lib/utils/icons';
 
 	interface Props {
@@ -25,15 +26,17 @@
 		onconfirm
 	}: Props = $props();
 
-	// Map the legacy Nuxt UI `confirmClass` hint onto a Skeleton preset color, the
-	// same substring matching the Vue original used to derive its UButton color.
-	const confirmPreset = $derived.by(() => {
+	// Map the legacy Nuxt UI `confirmClass` hint onto a Button color, the same
+	// substring matching the Vue original used to derive its UButton color. The
+	// Button renders `preset-filled-{color}-500` — byte-equivalent to the prior
+	// hand-rolled preset string.
+	const confirmColor = $derived.by<'primary' | 'surface' | 'error' | 'warning' | 'success'>(() => {
 		const c = confirmClass;
-		if (c.includes('error')) return 'preset-filled-error-500';
-		if (c.includes('warning')) return 'preset-filled-warning-500';
-		if (c.includes('success')) return 'preset-filled-success-500';
-		if (c.includes('neutral')) return 'preset-filled-surface-500';
-		return 'preset-filled-primary-500';
+		if (c.includes('error')) return 'error';
+		if (c.includes('warning')) return 'warning';
+		if (c.includes('success')) return 'success';
+		if (c.includes('neutral')) return 'surface';
+		return 'primary';
 	});
 </script>
 
@@ -48,27 +51,15 @@
 				<Dialog.Description class="text-sm opacity-75">{message}</Dialog.Description>
 			</header>
 			<footer class="flex w-full justify-end gap-2">
-				<button
-					type="button"
-					class="btn preset-tonal-surface"
-					disabled={pending}
-					onclick={() => (open = false)}
-				>
+				<Button variant="tonal" color="surface" disabled={pending} onclick={() => (open = false)}>
 					Cancel
-				</button>
-				<button
-					type="button"
-					class="btn {confirmPreset}"
-					disabled={pending}
-					onclick={() => onconfirm?.()}
-				>
-					{#if pending}
-						<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-					{:else}
+				</Button>
+				<Button color={confirmColor} loading={pending} onclick={() => onconfirm?.()}>
+					{#snippet icon()}
 						<AppIcon name={confirmIcon} class="size-4" />
-					{/if}
+					{/snippet}
 					{confirmLabel}
-				</button>
+				</Button>
 			</footer>
 		</Dialog.Content>
 	</Dialog.Positioner>

--- a/client/src/lib/components/ui/EmojiPicker.svelte
+++ b/client/src/lib/components/ui/EmojiPicker.svelte
@@ -194,7 +194,7 @@
 
 	{#if open}
 		<div
-			class="absolute top-full left-0 z-50 mt-2 w-72 card rounded-xl border border-surface-200-800 preset-filled-surface-50-950 p-3 shadow-lg"
+			class="absolute top-full left-0 z-50 mt-2 w-72 card rounded-lg border border-surface-200-800 preset-filled-surface-100-900 p-3 shadow-xl"
 		>
 			<div class="mb-2 flex items-center justify-between">
 				<span class="text-xs font-semibold opacity-60">Pick an icon</span>

--- a/client/src/lib/components/ui/EmptyState.svelte
+++ b/client/src/lib/components/ui/EmptyState.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	/**
+	 * EmptyState — the one "nothing here" treatment.
+	 *
+	 * A tinted round icon badge, a title, an optional muted description, and an
+	 * optional `actions` CTA row. Generalises the gold-standard `LibraryEmptyState`
+	 * pattern so every empty / zero-result / load-error view looks the same instead
+	 * of each route hand-rolling a bare one-liner. Pass `tone="error"` to surface a
+	 * failed load (distinct from a genuinely-empty result).
+	 */
+	import type { Snippet } from 'svelte';
+	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+
+	interface Props {
+		/** An ICONS registry value. */
+		icon: string;
+		title: string;
+		description?: string;
+		tone?: 'neutral' | 'error';
+		/** Optional CTA row rendered under the description. */
+		actions?: Snippet;
+	}
+
+	let { icon, title, description, tone = 'neutral', actions }: Props = $props();
+
+	const badgeClass = $derived(
+		tone === 'error' ? 'bg-error-500/10 text-error-500' : 'bg-surface-200-800 text-surface-500'
+	);
+</script>
+
+<div class="flex flex-col items-center justify-center px-4 py-16 text-center">
+	<div class={['mb-4 flex size-16 items-center justify-center rounded-full', badgeClass]}>
+		<AppIcon name={icon} class="size-8" />
+	</div>
+	<p class="text-lg font-medium">{title}</p>
+	{#if description}
+		<p class="mt-1 max-w-sm text-sm text-surface-600-400">{description}</p>
+	{/if}
+	{#if actions}
+		<div class="mt-4 flex items-center gap-2">
+			{@render actions()}
+		</div>
+	{/if}
+</div>

--- a/client/src/lib/components/ui/EmptyState.svelte.test.ts
+++ b/client/src/lib/components/ui/EmptyState.svelte.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { createRawSnippet } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import EmptyState from './EmptyState.svelte';
+import { ICONS } from '$lib/utils/icons';
+
+describe('EmptyState', () => {
+	it('renders the icon, title, and description', () => {
+		const screen = render(EmptyState, {
+			props: { icon: ICONS.search, title: 'No results', description: 'Try another query.' }
+		});
+		expect(screen.container.querySelector('svg')).not.toBeNull();
+		expect(screen.container.textContent).toContain('No results');
+		expect(screen.container.textContent).toContain('Try another query.');
+	});
+
+	it('omits the description and actions when not provided', () => {
+		const screen = render(EmptyState, { props: { icon: ICONS.search, title: 'Empty' } });
+		// Only the title paragraph renders.
+		expect(screen.container.querySelectorAll('p').length).toBe(1);
+	});
+
+	it('uses a neutral badge by default and an error badge for tone="error"', () => {
+		const neutral = render(EmptyState, { props: { icon: ICONS.search, title: 'Empty' } });
+		expect(neutral.container.querySelector('.rounded-full')?.className).toContain('text-surface-500');
+
+		const error = render(EmptyState, {
+			props: { icon: ICONS.warning, title: 'Failed', tone: 'error' }
+		});
+		expect(error.container.querySelector('.rounded-full')?.className).toContain('text-error-500');
+	});
+
+	it('renders the actions snippet', () => {
+		const actions = createRawSnippet(() => ({ render: () => `<button>Retry</button>` }));
+		const screen = render(EmptyState, {
+			props: { icon: ICONS.warning, title: 'Failed', actions }
+		});
+		expect(screen.container.textContent).toContain('Retry');
+	});
+});

--- a/client/src/lib/components/ui/EmptyState.svelte.test.ts
+++ b/client/src/lib/components/ui/EmptyState.svelte.test.ts
@@ -22,7 +22,9 @@ describe('EmptyState', () => {
 
 	it('uses a neutral badge by default and an error badge for tone="error"', () => {
 		const neutral = render(EmptyState, { props: { icon: ICONS.search, title: 'Empty' } });
-		expect(neutral.container.querySelector('.rounded-full')?.className).toContain('text-surface-500');
+		expect(neutral.container.querySelector('.rounded-full')?.className).toContain(
+			'text-surface-500'
+		);
 
 		const error = render(EmptyState, {
 			props: { icon: ICONS.warning, title: 'Failed', tone: 'error' }

--- a/client/src/lib/components/ui/OAuthGoogleButton.svelte
+++ b/client/src/lib/components/ui/OAuthGoogleButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { apiUrl } from '$lib/api';
+	import Button from '$lib/components/ui/Button.svelte';
 
 	interface Props {
 		href?: string;
@@ -14,29 +15,34 @@
 	const resolvedHref = $derived(apiUrl(href));
 </script>
 
-<a
+<Button
 	href={resolvedHref}
 	rel="external"
-	class="btn justify-center gap-2 preset-outlined-surface-500 btn-lg"
-	class:w-full={block}
+	variant="outlined"
+	color="surface"
+	size="lg"
+	fullWidth={block}
+	class="justify-center gap-2"
 >
-	<svg class="size-5" viewBox="0 0 24 24" aria-hidden="true">
-		<path
-			fill="#4285F4"
-			d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-		/>
-		<path
-			fill="#34A853"
-			d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-		/>
-		<path
-			fill="#FBBC05"
-			d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-		/>
-		<path
-			fill="#EA4335"
-			d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-		/>
-	</svg>
+	{#snippet icon()}
+		<svg class="size-5" viewBox="0 0 24 24" aria-hidden="true">
+			<path
+				fill="#4285F4"
+				d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+			/>
+			<path
+				fill="#34A853"
+				d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+			/>
+			<path
+				fill="#FBBC05"
+				d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+			/>
+			<path
+				fill="#EA4335"
+				d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+			/>
+		</svg>
+	{/snippet}
 	{label}
-</a>
+</Button>

--- a/client/src/lib/components/ui/PageHeader.svelte
+++ b/client/src/lib/components/ui/PageHeader.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	/**
+	 * PageHeader — the single page-title treatment for top-level routes.
+	 *
+	 * One `<h1>` scale (`text-2xl font-semibold`) + an optional muted description and
+	 * right-pinned `actions`, so every standalone screen's header looks the same
+	 * instead of each route hand-rolling its own size/weight (the survey found five
+	 * different page-title treatments). Library sub-tabs use `LibraryHeader` /
+	 * the breadcrumb instead — reach for this on the standalone routes (admin,
+	 * profile, search, notifications, tags, objects, people, …).
+	 */
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		title: string;
+		description?: string;
+		/** Right-pinned header actions (buttons, badges). */
+		actions?: Snippet;
+	}
+
+	let { title, description, actions }: Props = $props();
+</script>
+
+<div class="flex items-start justify-between gap-4">
+	<div class="min-w-0 space-y-0.5">
+		<h1 class="text-2xl font-semibold">{title}</h1>
+		{#if description}
+			<p class="text-sm text-surface-600-400">{description}</p>
+		{/if}
+	</div>
+	{#if actions}
+		<div class="flex shrink-0 items-center gap-2">
+			{@render actions()}
+		</div>
+	{/if}
+</div>

--- a/client/src/lib/components/ui/PageHeader.svelte.test.ts
+++ b/client/src/lib/components/ui/PageHeader.svelte.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { createRawSnippet } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import PageHeader from './PageHeader.svelte';
+
+describe('PageHeader', () => {
+	it('renders the title as an h1', () => {
+		const screen = render(PageHeader, { props: { title: 'Admin Dashboard' } });
+		const h1 = screen.container.querySelector('h1');
+		expect(h1?.textContent?.trim()).toBe('Admin Dashboard');
+		expect(h1?.className).toContain('text-2xl');
+	});
+
+	it('renders the description when provided and omits it otherwise', () => {
+		const withDesc = render(PageHeader, {
+			props: { title: 'Search', description: 'Find anything across your libraries.' }
+		});
+		expect(withDesc.container.textContent).toContain('Find anything across your libraries.');
+
+		const without = render(PageHeader, { props: { title: 'Search' } });
+		expect(without.container.querySelectorAll('p').length).toBe(0);
+	});
+
+	it('renders the actions snippet', () => {
+		const actions = createRawSnippet(() => ({ render: () => `<button>New</button>` }));
+		const screen = render(PageHeader, { props: { title: 'People', actions } });
+		expect(screen.container.textContent).toContain('New');
+	});
+});

--- a/client/src/lib/components/ui/StatCard.svelte
+++ b/client/src/lib/components/ui/StatCard.svelte
@@ -30,10 +30,10 @@
 <div class="card border border-surface-200-800 preset-tonal-surface p-4">
 	<div class="flex items-start justify-between gap-3">
 		<div class="min-w-0">
-			<p class="text-xs text-surface-500">{title}</p>
+			<p class="text-xs text-surface-600-400">{title}</p>
 			<p class="mt-1 text-3xl font-semibold">{value}</p>
 			{#if caption}
-				<p class="mt-1 text-xs text-surface-500">{caption}</p>
+				<p class="mt-1 text-xs text-surface-600-400">{caption}</p>
 			{/if}
 		</div>
 		<div class="flex size-10 shrink-0 items-center justify-center rounded-lg {iconClass}">

--- a/client/src/lib/components/ui/StatCard.svelte
+++ b/client/src/lib/components/ui/StatCard.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	/**
+	 * StatCard — a single metric tile: a label, a large value, an optional caption,
+	 * and a tinted icon badge. The one stat-card design shared across the app (the
+	 * admin dashboard and the background-jobs panel) so every metric tile is
+	 * visually identical. Built on the canonical tonal panel surface (matches
+	 * `AppPanel` / `Card` tone="tonal").
+	 */
+	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+
+	interface Props {
+		title: string;
+		value: string | number;
+		/** An ICONS registry value, e.g. `lineicons:files`. */
+		icon: string;
+		caption?: string;
+		/** Icon-badge tint (text + bg), e.g. `text-primary-500 bg-primary-500/10`. */
+		iconClass?: string;
+	}
+
+	let {
+		title,
+		value,
+		icon,
+		caption,
+		iconClass = 'text-primary-500 bg-primary-500/10'
+	}: Props = $props();
+</script>
+
+<div class="card border border-surface-200-800 preset-tonal-surface p-4">
+	<div class="flex items-start justify-between gap-3">
+		<div class="min-w-0">
+			<p class="text-xs text-surface-500">{title}</p>
+			<p class="mt-1 text-3xl font-semibold">{value}</p>
+			{#if caption}
+				<p class="mt-1 text-xs text-surface-500">{caption}</p>
+			{/if}
+		</div>
+		<div class="flex size-10 shrink-0 items-center justify-center rounded-lg {iconClass}">
+			<AppIcon name={icon} class="size-5" />
+		</div>
+	</div>
+</div>

--- a/client/src/lib/components/ui/StatCard.svelte.test.ts
+++ b/client/src/lib/components/ui/StatCard.svelte.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import StatCard from './StatCard.svelte';
+import { ICONS } from '$lib/utils/icons';
+
+describe('StatCard', () => {
+	it('renders the title, value, and icon on the canonical tonal surface', () => {
+		const screen = render(StatCard, {
+			props: { title: 'Files', value: '1,234', icon: ICONS.files }
+		});
+		const root = screen.container.querySelector('div.card');
+		expect(root).not.toBeNull();
+		expect(root?.className).toContain('preset-tonal-surface');
+		expect(root?.className).toContain('border');
+		expect(screen.container.textContent).toContain('Files');
+		expect(screen.container.textContent).toContain('1,234');
+		expect(screen.container.querySelector('svg')).not.toBeNull();
+	});
+
+	it('renders a numeric value', () => {
+		const screen = render(StatCard, { props: { title: 'Active', value: 7, icon: ICONS.files } });
+		expect(screen.container.textContent).toContain('7');
+	});
+
+	it('renders the optional caption when provided and omits it otherwise', () => {
+		const withCaption = render(StatCard, {
+			props: { title: 'Storage', value: '5 GB', icon: ICONS.storage, caption: 'Total disk usage' }
+		});
+		expect(withCaption.container.textContent).toContain('Total disk usage');
+
+		const without = render(StatCard, {
+			props: { title: 'Storage', value: '5 GB', icon: ICONS.storage }
+		});
+		// Only the title + value paragraphs render (no caption paragraph).
+		expect(without.container.querySelectorAll('p').length).toBe(2);
+	});
+
+	it('applies the icon-badge tint to the badge', () => {
+		const screen = render(StatCard, {
+			props: {
+				title: 'Failed',
+				value: 3,
+				icon: ICONS.files,
+				iconClass: 'text-error-500 bg-error-500/10'
+			}
+		});
+		const badge = screen.container.querySelector('div.rounded-lg');
+		expect(badge?.className).toContain('text-error-500');
+		expect(badge?.className).toContain('bg-error-500/10');
+	});
+
+	it('defaults the icon-badge tint to primary', () => {
+		const screen = render(StatCard, {
+			props: { title: 'Files', value: 1, icon: ICONS.files }
+		});
+		const badge = screen.container.querySelector('div.rounded-lg');
+		expect(badge?.className).toContain('text-primary-500');
+	});
+});

--- a/client/src/routes/(app)/+layout.server.ts
+++ b/client/src/routes/(app)/+layout.server.ts
@@ -15,11 +15,15 @@ export const load: LayoutServerLoad = async ({ locals, url, fetch }) => {
 
 	const api = createApi(fetch);
 	let libraries: Library[] = [];
+	let librariesError = false;
 	try {
 		libraries = await api.libraries.list();
 	} catch {
-		// Degrade to an empty sidebar rather than failing the whole authed shell.
+		// Degrade to an empty sidebar rather than failing the whole authed shell,
+		// but flag the failure so the sidebar can distinguish "no libraries" from
+		// "couldn't load".
+		librariesError = true;
 	}
 
-	return { user: locals.user, libraries };
+	return { user: locals.user, libraries, librariesError };
 };

--- a/client/src/routes/(app)/+layout.svelte
+++ b/client/src/routes/(app)/+layout.svelte
@@ -81,6 +81,7 @@
 					libraries={data.libraries}
 					user={data.user}
 					currentPath={page.url.pathname}
+					librariesError={data.librariesError}
 					oncreate={createLibrary}
 				/>
 			</Dialog.Content>

--- a/client/src/routes/(app)/+page.svelte
+++ b/client/src/routes/(app)/+page.svelte
@@ -3,6 +3,7 @@
 	import { api } from '$lib/api';
 	import { ICONS } from '$lib/utils/icons';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { toast } from '$lib/state/toast';
 	import type { PageProps } from './$types';
 
@@ -60,14 +61,12 @@
 						disabled={creating}
 					/>
 				</label>
-				<button
-					type="submit"
-					class="btn preset-filled-primary-500"
-					disabled={creating || name.trim().length === 0}
-				>
-					<AppIcon name={ICONS.plus} class="size-4" />
+				<Button type="submit" disabled={creating || name.trim().length === 0}>
+					{#snippet icon()}
+						<AppIcon name={ICONS.plus} class="size-4" />
+					{/snippet}
 					<span>{creating ? 'Creating…' : 'Create library'}</span>
-				</button>
+				</Button>
 			</form>
 		</div>
 	</div>

--- a/client/src/routes/(app)/admin/+page.svelte
+++ b/client/src/routes/(app)/admin/+page.svelte
@@ -7,6 +7,9 @@
 	import { formatFileSize } from '$lib/utils/mime-icons';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
 	import AppPanel from '$lib/components/ui/AppPanel.svelte';
+	import PageHeader from '$lib/components/ui/PageHeader.svelte';
+	import StatCard from '$lib/components/ui/StatCard.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import UserAvatar from '$lib/components/ui/UserAvatar.svelte';
 	import AdminJobsPanel from '$lib/components/admin/AdminJobsPanel.svelte';
 	import type { AdminStats, AdminUser, AppSettings, RegistrationMode } from '$lib/types/api';
@@ -33,11 +36,14 @@
 		void loadVersion();
 	});
 
+	let statsError = $state(false);
 	async function loadStats() {
+		statsError = false;
 		try {
 			stats = await api.admin.stats();
 		} catch {
 			stats = null;
+			statsError = true;
 		}
 	}
 
@@ -52,11 +58,14 @@
 		}
 	}
 
+	let settingsError = $state(false);
 	async function loadSettings() {
+		settingsError = false;
 		try {
 			settings = await api.admin.getSettings();
 		} catch {
 			settings = null;
+			settingsError = true;
 		}
 	}
 
@@ -483,29 +492,42 @@
 </script>
 
 <div class="min-h-0 flex-1 space-y-6 overflow-y-auto px-0.5">
-	<div>
-		<h1 class="text-2xl font-bold">Admin Dashboard</h1>
-		<p class="mt-0.5 text-sm text-surface-500">
-			Instance overview, user management, and background jobs.
-		</p>
-	</div>
+	<PageHeader
+		title="Admin Dashboard"
+		description="Instance overview, user management, and background jobs."
+	/>
+
+	{#if statsError}
+		<div
+			class="flex items-center gap-3 rounded-lg border border-error-500/30 bg-error-500/10 px-4 py-3 text-sm text-error-600"
+		>
+			<AppIcon name={ICONS.warning} class="size-5 shrink-0" />
+			<span class="flex-1">Couldn't load instance statistics.</span>
+			<button type="button" class="btn preset-tonal-error btn-sm" onclick={loadStats}>Retry</button>
+		</div>
+	{/if}
 
 	<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
 		{#each statCards as s (s.key)}
-			<div class="card border border-surface-200-800 preset-tonal-surface p-4">
-				<div class="flex items-start justify-between gap-3">
-					<div>
-						<p class="text-xs text-surface-500">{s.title}</p>
-						<p class="mt-1 text-3xl font-semibold">{s.value}</p>
-						<p class="mt-1 text-xs text-surface-500">{s.caption}</p>
-					</div>
-					<div class="flex size-10 items-center justify-center rounded-lg {s.color}">
-						<AppIcon name={s.icon} class="size-5" />
-					</div>
-				</div>
-			</div>
+			<StatCard
+				title={s.title}
+				value={s.value}
+				caption={s.caption}
+				icon={s.icon}
+				iconClass={s.color}
+			/>
 		{/each}
 	</div>
+
+	{#if settingsError}
+		<div
+			class="flex items-center gap-3 rounded-lg border border-error-500/30 bg-error-500/10 px-4 py-3 text-sm text-error-600"
+		>
+			<AppIcon name={ICONS.warning} class="size-5 shrink-0" />
+			<span class="flex-1">Couldn't load instance settings — values below may be inaccurate.</span>
+			<button type="button" class="btn preset-tonal-error btn-sm" onclick={loadSettings}>Retry</button>
+		</div>
+	{/if}
 
 	<AppPanel
 		title="Registration"
@@ -716,8 +738,22 @@
 					</tbody>
 				</table>
 			</div>
+		{:else if usersStatus === 'error'}
+			<EmptyState
+				icon={ICONS.warning}
+				title="Couldn't load users"
+				description="Something went wrong fetching the user list. Try again."
+				tone="error"
+			>
+				{#snippet actions()}
+					<button type="button" class="btn preset-tonal-surface" onclick={loadUsers}>
+						<AppIcon name={ICONS.reload} class="size-4" />
+						Retry
+					</button>
+				{/snippet}
+			</EmptyState>
 		{:else}
-			<p class="px-6 pb-6 text-sm text-surface-500">No users found.</p>
+			<EmptyState icon={ICONS.members} title="No users found" />
 		{/if}
 	</AppPanel>
 

--- a/client/src/routes/(app)/admin/+page.svelte
+++ b/client/src/routes/(app)/admin/+page.svelte
@@ -6,6 +6,7 @@
 	import { ICONS } from '$lib/utils/icons';
 	import { formatFileSize } from '$lib/utils/mime-icons';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import AppPanel from '$lib/components/ui/AppPanel.svelte';
 	import PageHeader from '$lib/components/ui/PageHeader.svelte';
 	import StatCard from '$lib/components/ui/StatCard.svelte';
@@ -503,7 +504,7 @@
 		>
 			<AppIcon name={ICONS.warning} class="size-5 shrink-0" />
 			<span class="flex-1">Couldn't load instance statistics.</span>
-			<button type="button" class="btn preset-tonal-error btn-sm" onclick={loadStats}>Retry</button>
+			<Button variant="tonal" color="error" size="sm" onclick={loadStats}>Retry</Button>
 		</div>
 	{/if}
 
@@ -525,7 +526,7 @@
 		>
 			<AppIcon name={ICONS.warning} class="size-5 shrink-0" />
 			<span class="flex-1">Couldn't load instance settings — values below may be inaccurate.</span>
-			<button type="button" class="btn preset-tonal-error btn-sm" onclick={loadSettings}>Retry</button>
+			<Button variant="tonal" color="error" size="sm" onclick={loadSettings}>Retry</Button>
 		</div>
 	{/if}
 
@@ -746,10 +747,12 @@
 				tone="error"
 			>
 				{#snippet actions()}
-					<button type="button" class="btn preset-tonal-surface" onclick={loadUsers}>
-						<AppIcon name={ICONS.reload} class="size-4" />
+					<Button variant="tonal" color="surface" onclick={loadUsers}>
+						{#snippet icon()}
+							<AppIcon name={ICONS.reload} class="size-4" />
+						{/snippet}
 						Retry
-					</button>
+					</Button>
 				{/snippet}
 			</EmptyState>
 		{:else}

--- a/client/src/routes/(app)/admin/page.svelte.test.ts
+++ b/client/src/routes/(app)/admin/page.svelte.test.ts
@@ -329,20 +329,20 @@ describe('/admin page', () => {
 		mocks.listUsers.mockResolvedValueOnce([]);
 		const screen = await renderPage();
 		await vi.waitFor(() => {
-			expect(screen.container.textContent).toContain('No users found.');
+			expect(screen.container.textContent).toContain('No users found');
 		});
-		// The count badge is only shown when users is a non-null array; an empty
-		// array still renders the "0" badge.
-		expect(screen.container.textContent).toContain('No users found.');
+		// A genuinely-empty list is distinct from a failed load: no error copy.
+		expect(screen.container.textContent).not.toContain("Couldn't load users");
 	});
 
-	it('falls back to an empty user list when listUsers rejects', async () => {
+	it('shows a distinct error state when listUsers rejects', async () => {
 		mocks.listUsers.mockRejectedValueOnce(new Error('boom'));
 		const screen = await renderPage();
 		await vi.waitFor(() => {
-			expect(screen.container.textContent).toContain('No users found.');
+			expect(screen.container.textContent).toContain("Couldn't load users");
 		});
-		expect(screen.container.textContent).toContain('No users found.');
+		// A load error must NOT masquerade as an empty result.
+		expect(screen.container.textContent).not.toContain('No users found');
 	});
 
 	it('rolls back the user list and toasts on a role-update failure', async () => {

--- a/client/src/routes/(app)/layout.server.test.ts
+++ b/client/src/routes/(app)/layout.server.test.ts
@@ -22,14 +22,20 @@ describe('(app) layout.server load', () => {
 		const result = (await call({ locals: { user: { id: 'u', role: 'member' } } })) as {
 			user: unknown;
 			libraries: unknown[];
+			librariesError: boolean;
 		};
 		expect(result.user).toEqual({ id: 'u', role: 'member' });
 		expect(result.libraries).toEqual([{ id: 'L1' }]);
+		expect(result.librariesError).toBe(false);
 	});
 
-	it('degrades to an empty library list when the API errors', async () => {
+	it('degrades to an empty library list and flags the error when the API fails', async () => {
 		listMock.mockRejectedValue(new Error('down'));
-		const result = (await call({ locals: { user: { id: 'u' } } })) as { libraries: unknown[] };
+		const result = (await call({ locals: { user: { id: 'u' } } })) as {
+			libraries: unknown[];
+			librariesError: boolean;
+		};
 		expect(result.libraries).toEqual([]);
+		expect(result.librariesError).toBe(true);
 	});
 });

--- a/client/src/routes/(app)/libraries/[id]/LibraryBrowser.svelte
+++ b/client/src/routes/(app)/libraries/[id]/LibraryBrowser.svelte
@@ -20,6 +20,7 @@
 	import { createFileDrop } from '$lib/state/file-drop.svelte';
 	import type { AuthUser, Library, LibraryEntry, LibraryFile, LibraryFolder } from '$lib/types/api';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import AppModal from '$lib/components/ui/AppModal.svelte';
 	import UploadModal from '$lib/components/UploadModal.svelte';
 	import FilePreview from '$lib/components/FilePreview.svelte';
@@ -1102,34 +1103,33 @@
 			{/if}
 
 			{#if trashed && !explorer.filesPending && explorer.totalCount > 0}
-				<button
-					type="button"
-					class="btn preset-tonal-error btn-sm"
-					onclick={() => openPurgeAllModal()}
-				>
-					<AppIcon name={ICONS.trash} class="size-4" />
+				<Button variant="tonal" color="error" size="sm" onclick={() => openPurgeAllModal()}>
+					{#snippet icon()}
+						<AppIcon name={ICONS.trash} class="size-4" />
+					{/snippet}
 					<span class="hidden sm:inline">Delete All</span>
-				</button>
+				</Button>
 			{/if}
 
 			{#if canManageLibrary && !trashed}
 				<div class="flex items-center gap-1.5">
-					<button
-						type="button"
-						class="btn h-9 preset-tonal-primary"
+					<Button
+						variant="tonal"
+						color="primary"
+						class="h-9"
 						onclick={() => folderActions.openCreateFolderModal()}
 					>
-						<AppIcon name={ICONS.folder} class="size-4" />
+						{#snippet icon()}
+							<AppIcon name={ICONS.folder} class="size-4" />
+						{/snippet}
 						<span class="hidden sm:inline">Folder</span>
-					</button>
-					<button
-						type="button"
-						class="btn h-9 preset-tonal-primary"
-						onclick={() => (uploadOpen = true)}
-					>
-						<AppIcon name={ICONS.upload} class="size-4" />
+					</Button>
+					<Button variant="tonal" color="primary" class="h-9" onclick={() => (uploadOpen = true)}>
+						{#snippet icon()}
+							<AppIcon name={ICONS.upload} class="size-4" />
+						{/snippet}
 						<span class="hidden sm:inline">Upload</span>
-					</button>
+					</Button>
 				</div>
 			{/if}
 		</div>
@@ -1340,19 +1340,18 @@
 			>
 				Cancel
 			</button>
-			<button
-				type="button"
-				class="btn preset-tonal-primary"
+			<Button
+				variant="tonal"
+				color="primary"
+				loading={folderActions.creatingFolder}
 				disabled={!folderActions.createFolderName.trim() || folderActions.creatingFolder}
 				onclick={() => folderActions.createFolder()}
 			>
-				{#if folderActions.creatingFolder}
-					<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-				{:else}
+				{#snippet icon()}
 					<AppIcon name={ICONS.folder} class="size-4" />
-				{/if}
+				{/snippet}
 				Create
-			</button>
+			</Button>
 		</div>
 	</AppModal>
 
@@ -1384,19 +1383,18 @@
 			>
 				Cancel
 			</button>
-			<button
-				type="button"
-				class="btn preset-tonal-primary"
+			<Button
+				variant="tonal"
+				color="primary"
+				loading={folderActions.moveFolderSaving}
 				disabled={folderActions.moveLoading || folderActions.moveFolderSaving}
 				onclick={() => folderActions.moveFolder()}
 			>
-				{#if folderActions.moveFolderSaving}
-					<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-				{:else}
+				{#snippet icon()}
 					<AppIcon name={ICONS.folder} class="size-4" />
-				{/if}
+				{/snippet}
 				Move
-			</button>
+			</Button>
 		</div>
 	</AppModal>
 
@@ -1423,19 +1421,18 @@
 		</div>
 		<div class="flex w-full justify-end gap-2">
 			<button type="button" class="btn preset-tonal" onclick={closeMoveFilesModal}>Cancel</button>
-			<button
-				type="button"
-				class="btn preset-tonal-primary"
+			<Button
+				variant="tonal"
+				color="primary"
+				loading={moveFilesSaving}
 				disabled={moveFilesLoading || moveFilesSaving}
 				onclick={() => moveFiles()}
 			>
-				{#if moveFilesSaving}
-					<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-				{:else}
+				{#snippet icon()}
 					<AppIcon name={ICONS.folder} class="size-4" />
-				{/if}
+				{/snippet}
 				Move
-			</button>
+			</Button>
 		</div>
 	</AppModal>
 
@@ -1468,15 +1465,16 @@
 			<button type="button" class="btn preset-tonal" onclick={() => (purgeModalOpen = false)}>
 				Cancel
 			</button>
-			<button
-				type="button"
-				class="btn preset-filled-error-500"
+			<Button
+				color="error"
 				disabled={purgeConfirmation !== 'delete'}
 				onclick={() => handlePermanentDelete()}
 			>
-				<AppIcon name={ICONS.trash} class="size-4" />
+				{#snippet icon()}
+					<AppIcon name={ICONS.trash} class="size-4" />
+				{/snippet}
 				Delete Permanently
-			</button>
+			</Button>
 		</div>
 	</AppModal>
 
@@ -1502,19 +1500,17 @@
 			<button type="button" class="btn preset-tonal" onclick={() => zip.cancelLargeDownload()}>
 				Cancel
 			</button>
-			<button
-				type="button"
-				class="btn preset-tonal-primary"
-				disabled={zip.downloading}
+			<Button
+				variant="tonal"
+				color="primary"
+				loading={zip.downloading}
 				onclick={() => zip.confirmLargeDownload()}
 			>
-				{#if zip.downloading}
-					<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-				{:else}
+				{#snippet icon()}
 					<AppIcon name={ICONS.download} class="size-4" />
-				{/if}
+				{/snippet}
 				Download Anyway
-			</button>
+			</Button>
 		</div>
 	</AppModal>
 </div>

--- a/client/src/routes/(app)/libraries/[id]/LibraryBrowser.svelte
+++ b/client/src/routes/(app)/libraries/[id]/LibraryBrowser.svelte
@@ -1230,7 +1230,7 @@
 	<!-- Context menu (replaces the Nuxt UContextMenu) -->
 	{#if contextMenuOpen}
 		<div
-			class="fixed z-50 flex w-56 flex-col gap-1 card rounded-md preset-filled-surface-50-950 p-1 shadow-xl"
+			class="fixed z-50 flex w-56 flex-col gap-1 card rounded-lg border border-surface-200-800 preset-filled-surface-100-900 p-1 shadow-xl"
 			style:left="{contextMenuX}px"
 			style:top="{contextMenuY}px"
 			role="menu"
@@ -1264,7 +1264,7 @@
 							</button>
 							{#if openSubmenuKey === `${gi}-${ii}`}
 								<div
-									class="absolute top-0 left-full ml-1 flex max-h-72 w-48 flex-col gap-1 overflow-y-auto card rounded-md preset-filled-surface-50-950 p-1 shadow-xl"
+									class="absolute top-0 left-full ml-1 flex max-h-72 w-48 flex-col gap-1 overflow-y-auto card rounded-lg border border-surface-200-800 preset-filled-surface-100-900 p-1 shadow-xl"
 								>
 									{#each item.children as child, ci (`${ci}-${child.label}`)}
 										<button

--- a/client/src/routes/(app)/libraries/[id]/feed/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/feed/+page.svelte
@@ -8,6 +8,7 @@
 	import { ICONS } from '$lib/utils/icons';
 	import NotificationItem from '$lib/components/notifications/NotificationItem.svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 
 	const libraryId = $derived(page.params.id ?? '');
 
@@ -41,10 +42,6 @@
 </script>
 
 <div class="flex h-full flex-col">
-	<div class="border-b border-surface-200-800 px-4 py-3">
-		<h2 class="text-base font-semibold">Activity feed</h2>
-		<p class="mt-0.5 text-xs text-surface-600-400">Everything that has happened in this library.</p>
-	</div>
 	<div class="min-h-0 flex-1 overflow-y-auto">
 		{#if feed.loading && feed.entries.length === 0}
 			<div class="px-4 py-8 text-center text-sm text-surface-600-400">
@@ -52,7 +49,11 @@
 				<p class="mt-2">Loading…</p>
 			</div>
 		{:else if feed.entries.length === 0}
-			<div class="px-4 py-12 text-center text-sm text-surface-600-400">No activity yet.</div>
+			<EmptyState
+				icon={ICONS.feed}
+				title="No activity yet"
+				description="Uploads, edits, and shares in this library will show up here."
+			/>
 		{:else}
 			<div class="divide-y divide-surface-200-800">
 				{#each groups as g (g.head.id)}

--- a/client/src/routes/(app)/libraries/[id]/feed/page.svelte.test.ts
+++ b/client/src/routes/(app)/libraries/[id]/feed/page.svelte.test.ts
@@ -101,10 +101,12 @@ beforeEach(() => {
 });
 
 describe('/libraries/[id]/feed', () => {
-	it('renders the header', async () => {
+	it('no longer renders the redundant in-page title bar', async () => {
+		// The library breadcrumb + the sidebar already identify the Feed tab, so the
+		// duplicate "Activity feed" sub-header was removed.
 		const screen = render(Page);
-		await expect.element(screen.getByText('Activity feed')).toBeInTheDocument();
-		expect(screen.container.textContent).toContain('Everything that has happened in this library');
+		expect(screen.container.textContent).not.toContain('Activity feed');
+		expect(screen.container.textContent).not.toContain('Everything that has happened');
 	});
 
 	it('shows the loading state while loading with no entries', async () => {
@@ -115,7 +117,7 @@ describe('/libraries/[id]/feed', () => {
 
 	it('shows the empty state when there is no activity', async () => {
 		const screen = render(Page);
-		await expect.element(screen.getByText('No activity yet.')).toBeInTheDocument();
+		await expect.element(screen.getByText('No activity yet')).toBeInTheDocument();
 	});
 
 	it('renders grouped activity rows', async () => {

--- a/client/src/routes/(app)/libraries/[id]/map/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/map/+page.svelte
@@ -74,17 +74,11 @@
 </script>
 
 <div class="flex h-full flex-col">
-	<div class="flex items-center justify-between gap-3 border-b border-surface-200-800 px-4 py-3">
-		<div class="min-w-0">
-			<h2 class="text-base font-semibold">Map</h2>
-			<p class="mt-0.5 text-xs text-surface-500">Where your photos were taken.</p>
+	{#if map.points.length > 0}
+		<div class="border-b border-surface-200-800 px-4 py-2 text-xs text-surface-500">
+			{map.points.length} geotagged {map.points.length === 1 ? 'photo' : 'photos'}
 		</div>
-		{#if map.points.length > 0}
-			<span class="shrink-0 text-xs text-surface-500">
-				{map.points.length} geotagged
-			</span>
-		{/if}
-	</div>
+	{/if}
 
 	{#if map.truncated}
 		<div

--- a/client/src/routes/(app)/libraries/[id]/map/page.svelte.test.ts
+++ b/client/src/routes/(app)/libraries/[id]/map/page.svelte.test.ts
@@ -97,10 +97,11 @@ describe('library map page', () => {
 		expect(store.load).toHaveBeenCalledWith('lib-1');
 	});
 
-	it('always renders the Map header', async () => {
+	it('does not render a redundant in-page Map title (breadcrumb identifies the tab)', async () => {
+		store.points = [makePoint('a')];
 		const screen = render(Page);
-		await expect.element(screen.getByRole('heading', { name: 'Map' })).toBeInTheDocument();
-		await expect.element(screen.getByText('Where your photos were taken.')).toBeInTheDocument();
+		expect(screen.container.querySelector('h2')).toBeNull();
+		expect(screen.container.textContent).not.toContain('Where your photos were taken.');
 	});
 
 	it('shows the loading spinner before any points arrive', async () => {
@@ -131,7 +132,7 @@ describe('library map page', () => {
 		// rendered once there are points to plot.
 		expect(screen.container.querySelector('.relative .absolute.inset-0')).not.toBeNull();
 		expect(screen.container.querySelector('[data-testid="map-stub"]')).not.toBeNull();
-		await expect.element(screen.getByText('2 geotagged')).toBeInTheDocument();
+		await expect.element(screen.getByText('2 geotagged photos')).toBeInTheDocument();
 		// The empty/loading overlays are gone when points are present.
 		expect(screen.container.textContent).not.toContain('No geotagged photos yet.');
 	});

--- a/client/src/routes/(app)/libraries/[id]/objects/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/objects/+page.svelte
@@ -7,6 +7,7 @@
 	import { portal } from '$lib/actions/portal';
 	import { toast } from '$lib/state/toast';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import type { ObjectLabel } from '$lib/types/api';
 	import type { PageProps } from './$types';
 
@@ -17,17 +18,20 @@
 
 	let labels = $state<ObjectLabel[]>([]);
 	let loading = $state(true);
+	let loadError = $state(false);
 	let reprocessing = $state(false);
 
 	const totalDetections = $derived(labels.reduce((sum, l) => sum + l.fileCount, 0));
 
 	async function load() {
 		loading = true;
+		loadError = false;
 		try {
 			const resp = await api.objects.labels(libraryId);
 			labels = resp.labels ?? [];
 		} catch {
 			labels = [];
+			loadError = true;
 		} finally {
 			loading = false;
 		}
@@ -76,18 +80,28 @@
 <div class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-0.5">
 	{#if loading}
 		<div class="flex items-center justify-center py-12">
-			<AppIcon name={ICONS.loading} class="text-dimmed size-6 animate-spin" />
+			<AppIcon name={ICONS.loading} class="size-6 animate-spin text-surface-600-400" />
 		</div>
-	{:else if labels.length === 0}
-		<div
-			class="flex items-start gap-3 rounded-lg border border-surface-200-800 bg-surface-100-900 p-4"
+	{:else if loadError}
+		<EmptyState
+			icon={ICONS.warning}
+			title="Couldn't load object labels"
+			description="Something went wrong fetching detections. Try again."
+			tone="error"
 		>
-			<AppIcon name={ICONS.objectDetection} class="mt-0.5 size-5 text-surface-500" />
-			<div>
-				<p class="text-sm font-medium">No objects detected yet</p>
-				<p class="text-sm text-surface-500">Upload images to start detecting objects.</p>
-			</div>
-		</div>
+			{#snippet actions()}
+				<button type="button" class="btn preset-tonal-surface" onclick={load}>
+					<AppIcon name={ICONS.reload} class="size-4" />
+					Retry
+				</button>
+			{/snippet}
+		</EmptyState>
+	{:else if labels.length === 0}
+		<EmptyState
+			icon={ICONS.objectDetection}
+			title="No objects detected yet"
+			description="Upload images to start detecting objects across this library."
+		/>
 	{:else}
 		<div class="flex items-center gap-2 text-sm">
 			<span class="badge preset-tonal-surface">{labels.length} labels</span>

--- a/client/src/routes/(app)/libraries/[id]/objects/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/objects/+page.svelte
@@ -7,6 +7,7 @@
 	import { portal } from '$lib/actions/portal';
 	import { toast } from '$lib/state/toast';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import type { ObjectLabel } from '$lib/types/api';
 	import type { PageProps } from './$types';
@@ -62,18 +63,15 @@
 {#if canManage}
 	<!-- Injected into the library header's action row (see +layout.svelte). -->
 	<div use:portal={'#library-header-actions'}>
-		<button
-			type="button"
-			class="btn preset-tonal-surface btn-sm"
-			disabled={reprocessing}
-			onclick={reprocess}
-		>
-			<AppIcon
-				name={ICONS.objectDetection}
-				class={['size-4', reprocessing && 'animate-spin'].filter(Boolean).join(' ')}
-			/>
+		<Button variant="tonal" color="surface" size="sm" disabled={reprocessing} onclick={reprocess}>
+			{#snippet icon()}
+				<AppIcon
+					name={ICONS.objectDetection}
+					class={['size-4', reprocessing && 'animate-spin'].filter(Boolean).join(' ')}
+				/>
+			{/snippet}
 			<span>{reprocessing ? 'Queuing…' : 'Reprocess'}</span>
-		</button>
+		</Button>
 	</div>
 {/if}
 
@@ -90,10 +88,12 @@
 			tone="error"
 		>
 			{#snippet actions()}
-				<button type="button" class="btn preset-tonal-surface" onclick={load}>
-					<AppIcon name={ICONS.reload} class="size-4" />
+				<Button variant="tonal" color="surface" onclick={load}>
+					{#snippet icon()}
+						<AppIcon name={ICONS.reload} class="size-4" />
+					{/snippet}
 					Retry
-				</button>
+				</Button>
 			{/snippet}
 		</EmptyState>
 	{:else if labels.length === 0}

--- a/client/src/routes/(app)/libraries/[id]/objects/page.svelte.test.ts
+++ b/client/src/routes/(app)/libraries/[id]/objects/page.svelte.test.ts
@@ -101,6 +101,14 @@ describe('/libraries/[id]/objects', () => {
 		await expect.element(screen.getByText('No objects detected yet')).toBeInTheDocument();
 	});
 
+	it('shows a distinct error state when the labels request fails', async () => {
+		apiMock.objects.labels.mockRejectedValueOnce(new Error('boom'));
+		const screen = render(Page, { props: props() });
+		await expect.element(screen.getByText("Couldn't load object labels")).toBeInTheDocument();
+		// A load error must not be shown as a genuinely-empty result.
+		expect(screen.container.textContent).not.toContain('No objects detected yet');
+	});
+
 	it('renders the labels table with badges and counts', async () => {
 		state.labels = [
 			{ label: 'person', fileCount: 12 },

--- a/client/src/routes/(app)/libraries/[id]/people/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/people/+page.svelte
@@ -5,6 +5,7 @@
 	import { ICONS } from '$lib/utils/icons';
 	import { createLibraryPeople } from '$lib/state/library-people.svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import AppModal from '$lib/components/ui/AppModal.svelte';
 
@@ -85,18 +86,14 @@
 	<div class="grid gap-4">
 		{#if people.selectedPeople.size >= 2}
 			<div class="flex items-center gap-2">
-				<button
-					type="button"
-					class="btn preset-filled-primary-500 btn-sm"
-					onclick={() => people.mergePeople()}
-				>
-					<AppIcon name={ICONS.mergePeople} class="size-4" />
+				<Button size="sm" onclick={() => people.mergePeople()}>
+					{#snippet icon()}
+						<AppIcon name={ICONS.mergePeople} class="size-4" />
+					{/snippet}
 					<span>Merge Selected</span>
-				</button>
+				</Button>
 				<span class="text-sm opacity-75">{people.selectedPeople.size} selected</span>
-				<button type="button" class="btn preset-tonal-surface btn-sm" onclick={clearSelection}>
-					Clear
-				</button>
+				<Button variant="tonal" color="surface" size="sm" onclick={clearSelection}>Clear</Button>
 			</div>
 		{/if}
 
@@ -177,25 +174,23 @@
 		</div>
 
 		<div class="flex w-full justify-end gap-2">
-			<button
-				type="button"
-				class="btn preset-tonal-surface btn-sm"
+			<Button
+				variant="tonal"
+				color="surface"
+				size="sm"
 				disabled={!!renamingPersonSavingId}
 				onclick={closeRenamePersonModal}
 			>
 				Cancel
-			</button>
-			<button
-				type="button"
-				class="btn preset-filled-primary-500 btn-sm"
+			</Button>
+			<Button
+				size="sm"
+				loading={!!renamingPersonSavingId}
 				disabled={!!renamingPersonSavingId || !renamePersonTarget}
 				onclick={confirmRenamePerson}
 			>
-				{#if renamingPersonSavingId}
-					<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-				{/if}
 				<span>Save</span>
-			</button>
+			</Button>
 		</div>
 	</AppModal>
 </div>

--- a/client/src/routes/(app)/libraries/[id]/people/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/people/+page.svelte
@@ -5,6 +5,7 @@
 	import { ICONS } from '$lib/utils/icons';
 	import { createLibraryPeople } from '$lib/state/library-people.svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import AppModal from '$lib/components/ui/AppModal.svelte';
 
 	/**
@@ -149,15 +150,11 @@
 				</div>
 			</div>
 		{:else}
-			<div class="flex flex-col items-center justify-center px-4 py-16">
-				<div class="mb-4 flex size-16 items-center justify-center rounded-full bg-surface-100-900">
-					<AppIcon name={ICONS.people} class="size-8 opacity-75" />
-				</div>
-				<p class="mb-1 text-lg font-medium">No faces detected yet</p>
-				<p class="max-w-md text-center text-sm opacity-75">
-					Upload images to this library and faces will be automatically detected and grouped.
-				</p>
-			</div>
+			<EmptyState
+				icon={ICONS.people}
+				title="No faces detected yet"
+				description="Upload images to this library and faces will be automatically detected and grouped."
+			/>
 		{/if}
 	</div>
 

--- a/client/src/routes/(app)/libraries/[id]/people/[personId]/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/people/[personId]/+page.svelte
@@ -208,7 +208,7 @@
 	<!-- The window listener closes the menu on any click; stop propagation here so a
 	     click inside the menu (on the items) doesn't immediately dismiss it. -->
 	<div
-		class="fixed z-50 w-56 card rounded-md border border-surface-200-800 preset-filled-surface-50-950 p-1 shadow-lg"
+		class="fixed z-50 w-56 card rounded-lg border border-surface-200-800 preset-filled-surface-100-900 p-1 shadow-xl"
 		style="left: {menuX}px; top: {menuY}px;"
 		role="menu"
 		tabindex="-1"

--- a/client/src/routes/(app)/libraries/[id]/people/[personId]/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/people/[personId]/+page.svelte
@@ -8,6 +8,7 @@
 	import { createLibraryPeople } from '$lib/state/library-people.svelte';
 	import type { LibraryFile, PersonFace } from '$lib/types/api';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import AlcovesImage from '$lib/components/ui/AlcovesImage.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import FilePreview from '$lib/components/FilePreview.svelte';
@@ -160,10 +161,12 @@
 			description="This person no longer exists in this library."
 		>
 			{#snippet actions()}
-				<button type="button" class="btn preset-tonal-surface" onclick={goBack}>
-					<AppIcon name={ICONS.back} class="size-4" />
+				<Button variant="tonal" color="surface" onclick={goBack}>
+					{#snippet icon()}
+						<AppIcon name={ICONS.back} class="size-4" />
+					{/snippet}
 					Back to People
-				</button>
+				</Button>
 			{/snippet}
 		</EmptyState>
 	{:else if faces.length}

--- a/client/src/routes/(app)/libraries/[id]/people/[personId]/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/people/[personId]/+page.svelte
@@ -9,6 +9,7 @@
 	import type { LibraryFile, PersonFace } from '$lib/types/api';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
 	import AlcovesImage from '$lib/components/ui/AlcovesImage.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import FilePreview from '$lib/components/FilePreview.svelte';
 
 	// This page reads route params (and the people store) rather than the layout's
@@ -153,16 +154,18 @@
 			<AppIcon name={ICONS.loading} class="size-5 animate-spin text-surface-600-400" />
 		</div>
 	{:else if !person}
-		<div class="flex flex-col items-center justify-center gap-3 px-4 py-16">
-			<p class="text-sm text-surface-600-400">Person not found in this library</p>
-			<button
-				type="button"
-				class="rounded-md bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-600"
-				onclick={goBack}
-			>
-				Back to People
-			</button>
-		</div>
+		<EmptyState
+			icon={ICONS.person}
+			title="Person not found"
+			description="This person no longer exists in this library."
+		>
+			{#snippet actions()}
+				<button type="button" class="btn preset-tonal-surface" onclick={goBack}>
+					<AppIcon name={ICONS.back} class="size-4" />
+					Back to People
+				</button>
+			{/snippet}
+		</EmptyState>
 	{:else if faces.length}
 		<div class="grid grid-cols-4 gap-2 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10">
 			{#each faces as face (face.id)}
@@ -189,9 +192,11 @@
 			{/each}
 		</div>
 	{:else}
-		<div class="flex items-center justify-center py-16">
-			<p class="text-sm text-surface-600-400">No faces available for this person</p>
-		</div>
+		<EmptyState
+			icon={ICONS.people}
+			title="No faces available"
+			description="There are no face crops to show for this person yet."
+		/>
 	{/if}
 </div>
 

--- a/client/src/routes/(app)/libraries/[id]/people/[personId]/page.svelte.test.ts
+++ b/client/src/routes/(app)/libraries/[id]/people/[personId]/page.svelte.test.ts
@@ -200,7 +200,7 @@ describe('person detail page', () => {
 
 		const screen = render(Page);
 
-		await expect.element(screen.getByText('Person not found in this library')).toBeInTheDocument();
+		await expect.element(screen.getByText('Person not found')).toBeInTheDocument();
 		const back = screen.getByRole('button', { name: 'Back to People' });
 		await back.click();
 		expect(goto).toHaveBeenCalledWith('/libraries/lib-1/people');
@@ -216,9 +216,7 @@ describe('person detail page', () => {
 
 		const screen = render(Page);
 
-		await expect
-			.element(screen.getByText('No faces available for this person'))
-			.toBeInTheDocument();
+		await expect.element(screen.getByText('No faces available')).toBeInTheDocument();
 	});
 
 	it('renders a tile per face and opens the file preview on click', async () => {

--- a/client/src/routes/(app)/libraries/[id]/settings/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/settings/+page.svelte
@@ -9,6 +9,7 @@
 	import { canManageLibrary } from '$lib/utils/permissions';
 	import { ICONS } from '$lib/utils/icons';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import AppPanelRow from '$lib/components/ui/AppPanelRow.svelte';
 	import ConfirmModal from '$lib/components/ui/ConfirmModal.svelte';
 	import EmojiPicker from '$lib/components/ui/EmojiPicker.svelte';
@@ -432,19 +433,18 @@
 						if (e.key === 'Enter') saveLibraryNameFromSettings();
 					}}
 				/>
-				<button
-					type="button"
-					class="btn preset-tonal-primary"
+				<Button
+					variant="tonal"
+					color="primary"
+					loading={savingLibraryName}
 					disabled={!canSaveName}
 					onclick={saveLibraryNameFromSettings}
 				>
-					{#if savingLibraryName}
-						<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-					{:else}
+					{#snippet icon()}
 						<AppIcon name={ICONS.check} class="size-4" />
-					{/if}
+					{/snippet}
 					Save
-				</button>
+				</Button>
 			</div>
 		</SettingsSection>
 
@@ -478,19 +478,12 @@
 								<span class="mb-1 block text-xs font-medium">Expires at</span>
 								<input bind:value={newLinkExpiresAt} type="datetime-local" class="input w-full" />
 							</label>
-							<button
-								type="button"
-								class="btn preset-filled-primary-500"
-								disabled={members.createInviteLinkLoading}
-								onclick={submitCreateInviteLink}
-							>
-								{#if members.createInviteLinkLoading}
-									<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-								{:else}
+							<Button loading={members.createInviteLinkLoading} onclick={submitCreateInviteLink}>
+								{#snippet icon()}
 									<AppIcon name={ICONS.link} class="size-4" />
-								{/if}
+								{/snippet}
 								Create Link
-							</button>
+							</Button>
 						</div>
 						<p class="text-xs text-surface-600-400">
 							Leave both fields blank for unlimited uses that never expire.
@@ -577,19 +570,18 @@
 					title="Queue full reprocessing"
 					description="Deletes current face inference data, then re-runs detection on all images."
 				>
-					<button
-						type="button"
-						class="btn preset-tonal-warning"
+					<Button
+						variant="tonal"
+						color="warning"
+						loading={faceRecReprocessing}
 						disabled={!library?.faceRecognitionEnabled || faceRecToggling || faceRecReprocessing}
 						onclick={() => (faceRecReprocessOpen = true)}
 					>
-						{#if faceRecReprocessing}
-							<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-						{:else}
+						{#snippet icon()}
 							<AppIcon name={ICONS.reload} class="size-4" />
-						{/if}
+						{/snippet}
 						Reprocess Faces
-					</button>
+					</Button>
 				</AppPanelRow>
 			</div>
 		</SettingsSection>
@@ -622,16 +614,18 @@
 					title="Browse detected objects"
 					description="View detected object labels and their frequency across the library."
 				>
-					<a
-						class="btn preset-tonal-surface"
-						class:pointer-events-none={!library?.objectDetectionEnabled}
-						class:opacity-50={!library?.objectDetectionEnabled}
-						aria-disabled={!library?.objectDetectionEnabled}
+					<Button
+						variant="tonal"
+						color="surface"
 						href={`/libraries/${libraryId}/objects`}
+						disabled={!library?.objectDetectionEnabled}
+						class={!library?.objectDetectionEnabled ? 'opacity-50' : ''}
 					>
-						<AppIcon name={ICONS.objectDetection} class="size-4" />
+						{#snippet icon()}
+							<AppIcon name={ICONS.objectDetection} class="size-4" />
+						{/snippet}
 						View Objects
-					</a>
+					</Button>
 				</AppPanelRow>
 
 				<hr class="hr" />
@@ -640,19 +634,18 @@
 					title="Queue full reprocessing"
 					description="Deletes current object detection data, then re-runs detection on all images."
 				>
-					<button
-						type="button"
-						class="btn preset-tonal-warning"
+					<Button
+						variant="tonal"
+						color="warning"
+						loading={objDetReprocessing}
 						disabled={!library?.objectDetectionEnabled || objDetToggling || objDetReprocessing}
 						onclick={() => (objDetReprocessOpen = true)}
 					>
-						{#if objDetReprocessing}
-							<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-						{:else}
+						{#snippet icon()}
 							<AppIcon name={ICONS.reload} class="size-4" />
-						{/if}
+						{/snippet}
 						Reprocess Objects
-					</button>
+					</Button>
 				</AppPanelRow>
 			</div>
 		</SettingsSection>
@@ -667,19 +660,17 @@
 				title="Re-transcribe all videos"
 				description="Queues transcription for every video and audio file in this library, overwriting existing transcripts. Useful after a model upgrade or hallucination-fix rollout."
 			>
-				<button
-					type="button"
-					class="btn preset-tonal-warning"
-					disabled={transcribeReprocessing}
+				<Button
+					variant="tonal"
+					color="warning"
+					loading={transcribeReprocessing}
 					onclick={() => (transcribeReprocessOpen = true)}
 				>
-					{#if transcribeReprocessing}
-						<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-					{:else}
+					{#snippet icon()}
 						<AppIcon name={ICONS.transcript} class="size-4" />
-					{/if}
+					{/snippet}
 					Reprocess Transcripts
-				</button>
+				</Button>
 			</AppPanelRow>
 		</SettingsSection>
 
@@ -693,19 +684,17 @@
 				title="Re-run audio detection on all videos"
 				description="Queues PANNs detection for every video and audio file with a ready transcript, overwriting existing audio-event tags."
 			>
-				<button
-					type="button"
-					class="btn preset-tonal-warning"
-					disabled={audioDetectReprocessing}
+				<Button
+					variant="tonal"
+					color="warning"
+					loading={audioDetectReprocessing}
 					onclick={() => (audioDetectReprocessOpen = true)}
 				>
-					{#if audioDetectReprocessing}
-						<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-					{:else}
+					{#snippet icon()}
 						<AppIcon name={ICONS.audioDetect} class="size-4" />
-					{/if}
+					{/snippet}
 					Reprocess Audio Detections
-				</button>
+				</Button>
 			</AppPanelRow>
 		</SettingsSection>
 
@@ -739,19 +728,17 @@
 				icon={ICONS.image}
 			>
 				<div class="flex sm:justify-end">
-					<button
-						type="button"
-						class="btn preset-tonal-warning"
-						disabled={videoThumbReprocessing}
+					<Button
+						variant="tonal"
+						color="warning"
+						loading={videoThumbReprocessing}
 						onclick={() => (videoThumbReprocessOpen = true)}
 					>
-						{#if videoThumbReprocessing}
-							<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-						{:else}
+						{#snippet icon()}
 							<AppIcon name={ICONS.image} class="size-4" />
-						{/if}
+						{/snippet}
 						Regenerate Thumbnails
-					</button>
+					</Button>
 				</div>
 			</SettingsSection>
 		{/if}
@@ -764,19 +751,17 @@
 				icon={ICONS.location}
 			>
 				<div class="flex sm:justify-end">
-					<button
-						type="button"
-						class="btn preset-tonal-warning"
-						disabled={metadataReprocessing}
+					<Button
+						variant="tonal"
+						color="warning"
+						loading={metadataReprocessing}
 						onclick={() => (metadataReprocessOpen = true)}
 					>
-						{#if metadataReprocessing}
-							<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-						{:else}
+						{#snippet icon()}
 							<AppIcon name={ICONS.reload} class="size-4" />
-						{/if}
+						{/snippet}
 						Reprocess Metadata
-					</button>
+					</Button>
 				</div>
 			</SettingsSection>
 		{/if}
@@ -794,15 +779,17 @@
 				description="Permanently remove this library. Must be empty first."
 				danger
 			>
-				<button
-					type="button"
-					class="btn preset-tonal-error"
+				<Button
+					variant="tonal"
+					color="error"
 					disabled={!canDeleteLibrary}
 					onclick={() => (deleteLibraryOpen = true)}
 				>
-					<AppIcon name={ICONS.trash} class="size-4" />
+					{#snippet icon()}
+						<AppIcon name={ICONS.trash} class="size-4" />
+					{/snippet}
 					Delete
-				</button>
+				</Button>
 			</AppPanelRow>
 		</SettingsSection>
 	</div>
@@ -880,27 +867,20 @@
 		description="This will permanently delete all detected object data for this library. This action cannot be undone."
 	>
 		<div class="flex w-full justify-end gap-2">
-			<button
-				type="button"
-				class="btn preset-tonal-surface"
+			<Button
+				variant="tonal"
+				color="surface"
 				disabled={objDetToggling}
 				onclick={() => (objDetDisableOpen = false)}
 			>
 				Cancel
-			</button>
-			<button
-				type="button"
-				class="btn preset-filled-error-500"
-				disabled={objDetToggling}
-				onclick={confirmDisableObjectDetection}
-			>
-				{#if objDetToggling}
-					<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-				{:else}
+			</Button>
+			<Button color="error" loading={objDetToggling} onclick={confirmDisableObjectDetection}>
+				{#snippet icon()}
 					<AppIcon name={ICONS.trash} class="size-4" />
-				{/if}
+				{/snippet}
 				Disable & Delete Data
-			</button>
+			</Button>
 		</div>
 	</AppModal>
 
@@ -911,27 +891,20 @@
 		description="This deletes all existing object detection data and queues a full rebuild. Detected objects may change if the model or settings have been updated."
 	>
 		<div class="flex w-full justify-end gap-2">
-			<button
-				type="button"
-				class="btn preset-tonal-surface"
+			<Button
+				variant="tonal"
+				color="surface"
 				disabled={objDetReprocessing}
 				onclick={() => (objDetReprocessOpen = false)}
 			>
 				Cancel
-			</button>
-			<button
-				type="button"
-				class="btn preset-filled-warning-500"
-				disabled={objDetReprocessing}
-				onclick={reprocessObjectDetection}
-			>
-				{#if objDetReprocessing}
-					<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-				{:else}
+			</Button>
+			<Button color="warning" loading={objDetReprocessing} onclick={reprocessObjectDetection}>
+				{#snippet icon()}
 					<AppIcon name={ICONS.reload} class="size-4" />
-				{/if}
+				{/snippet}
 				Delete Data & Requeue
-			</button>
+			</Button>
 		</div>
 	</AppModal>
 
@@ -954,22 +927,20 @@
 		</div>
 
 		<div class="flex w-full justify-end gap-2">
-			<button
-				type="button"
-				class="btn preset-tonal-surface"
-				onclick={() => (deleteLibraryOpen = false)}
-			>
+			<Button variant="tonal" color="surface" onclick={() => (deleteLibraryOpen = false)}>
 				Cancel
-			</button>
-			<button
-				type="button"
-				class="btn preset-tonal-error"
+			</Button>
+			<Button
+				variant="tonal"
+				color="error"
 				disabled={deleteLibraryConfirmation !== 'delete'}
 				onclick={deleteLibrary}
 			>
-				<AppIcon name={ICONS.trash} class="size-4" />
+				{#snippet icon()}
+					<AppIcon name={ICONS.trash} class="size-4" />
+				{/snippet}
 				Delete Library
-			</button>
+			</Button>
 		</div>
 	</AppModal>
 </div>

--- a/client/src/routes/(app)/libraries/[id]/tags/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/tags/+page.svelte
@@ -8,6 +8,7 @@
 	import { ICONS } from '$lib/utils/icons';
 	import AppPanel from '$lib/components/ui/AppPanel.svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import TagColorPickerDropdown from '$lib/components/library/TagColorPickerDropdown.svelte';
 	import type { LibraryEntry, LibraryTag } from '$lib/types/api';
 
@@ -246,20 +247,18 @@
 						if (e.key === 'Enter') createTagAndRefresh();
 					}}
 				/>
-				<button
-					type="button"
-					class="btn preset-filled-primary-500 btn-sm"
+				<Button
+					size="sm"
 					aria-label="Add tag"
+					loading={tags.creatingTag}
 					disabled={!tags.createTagName.trim() || tags.creatingTag}
 					onclick={createTagAndRefresh}
 				>
-					{#if tags.creatingTag}
-						<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-					{:else}
+					{#snippet icon()}
 						<AppIcon name={ICONS.plus} class="size-4" />
-					{/if}
+					{/snippet}
 					<span>Add</span>
-				</button>
+				</Button>
 			</div>
 
 			{#if loading}
@@ -322,14 +321,19 @@
 							{/if}
 						</span>
 
-						<button
-							type="button"
-							class="btn-icon btn-icon-sm shrink-0 preset-tonal-error opacity-60 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
+						<Button
+							iconOnly
+							size="sm"
+							variant="tonal"
+							color="error"
+							class="shrink-0 opacity-60 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
 							aria-label={`Delete tag ${tag.name}`}
 							onclick={() => deleteTagAndRefresh(tag.id)}
 						>
-							<AppIcon name={ICONS.trash} class="size-4" />
-						</button>
+							{#snippet icon()}
+								<AppIcon name={ICONS.trash} class="size-4" />
+							{/snippet}
+						</Button>
 					</div>
 				{/each}
 			{/if}

--- a/client/src/routes/(app)/libraries/[id]/tags/+page.svelte
+++ b/client/src/routes/(app)/libraries/[id]/tags/+page.svelte
@@ -215,7 +215,7 @@
 	});
 </script>
 
-<div class="flex w-full flex-1 flex-col gap-4 overflow-y-auto px-0.5 pb-6">
+<div class="flex min-h-0 w-full flex-1 flex-col gap-4 overflow-y-auto px-0.5 pb-6">
 	<AppPanel
 		title="Tags"
 		description="Colored labels you attach to files and folders."

--- a/client/src/routes/(app)/notifications/+page.svelte
+++ b/client/src/routes/(app)/notifications/+page.svelte
@@ -6,6 +6,8 @@
 	import { groupActivities, type ActivityGroup } from '$lib/utils/activity-format';
 	import { ICONS } from '$lib/utils/icons';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import PageHeader from '$lib/components/ui/PageHeader.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import NotificationItem from '$lib/components/notifications/NotificationItem.svelte';
 
 	let unsubscribe: (() => void) | null = null;
@@ -51,20 +53,20 @@
 </script>
 
 <div class="flex h-full flex-col">
-	<div class="flex items-center justify-between border-b border-surface-200-800 px-4 py-3">
-		<div>
-			<h1 class="text-lg font-semibold">Notifications</h1>
-			<p class="mt-0.5 text-xs text-surface-600-400">Activity across all your libraries.</p>
-		</div>
-		{#if notifications.entries.length > 0}
-			<button
-				type="button"
-				class="text-sm text-surface-600-400 underline hover:text-surface-950-50"
-				onclick={() => notifications.dismissAll()}
-			>
-				Dismiss all
-			</button>
-		{/if}
+	<div class="border-b border-surface-200-800 px-4 py-3">
+		<PageHeader title="Notifications" description="Activity across all your libraries.">
+			{#snippet actions()}
+				{#if notifications.entries.length > 0}
+					<button
+						type="button"
+						class="text-sm text-surface-600-400 underline hover:text-surface-950-50"
+						onclick={() => notifications.dismissAll()}
+					>
+						Dismiss all
+					</button>
+				{/if}
+			{/snippet}
+		</PageHeader>
 	</div>
 	<div class="min-h-0 flex-1 overflow-y-auto">
 		{#if notifications.loading && notifications.entries.length === 0}
@@ -73,7 +75,11 @@
 				<p class="mt-2">Loading…</p>
 			</div>
 		{:else if notifications.entries.length === 0}
-			<div class="px-4 py-12 text-center text-sm text-surface-600-400">You're all caught up.</div>
+			<EmptyState
+				icon={ICONS.bell}
+				title="You're all caught up"
+				description="New activity across your libraries will appear here."
+			/>
 		{:else}
 			{#each groupedByLibrary as lib (lib.libraryId)}
 				<section class="border-b border-surface-200-800">

--- a/client/src/routes/(app)/notifications/page.svelte.test.ts
+++ b/client/src/routes/(app)/notifications/page.svelte.test.ts
@@ -117,7 +117,7 @@ describe('/notifications page', () => {
 
 	it('shows the empty state when there are no notifications', async () => {
 		const screen = render(Page);
-		await expect.element(screen.getByText("You're all caught up.")).toBeInTheDocument();
+		await expect.element(screen.getByText("You're all caught up")).toBeInTheDocument();
 	});
 
 	it('renders the header and groups rows under their library name', async () => {

--- a/client/src/routes/(app)/profile/+page.svelte
+++ b/client/src/routes/(app)/profile/+page.svelte
@@ -8,6 +8,7 @@
 	import { ICONS } from '$lib/utils/icons';
 	import AppPanel from '$lib/components/ui/AppPanel.svelte';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import AccessTokensSection from '$lib/components/profile/AccessTokensSection.svelte';
 	import type { PageProps } from './$types';
 	import type { SessionInfo } from '$lib/types/api';
@@ -242,19 +243,12 @@
 		icon={ICONS.person}
 	>
 		{#snippet actions()}
-			<button
-				type="button"
-				class="btn preset-filled-primary-500"
-				disabled={!hasProfileChanges || saving}
-				onclick={save}
-			>
-				{#if saving}
-					<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-				{:else}
+			<Button loading={saving} disabled={!hasProfileChanges || saving} onclick={save}>
+				{#snippet icon()}
 					<AppIcon name={ICONS.save} class="size-4" />
-				{/if}
+				{/snippet}
 				Save changes
-			</button>
+			</Button>
 		{/snippet}
 
 		<div class="space-y-4">
@@ -271,9 +265,7 @@
 						<AppIcon name={ICONS.camera} class="size-4 shrink-0" />
 						New photo selected — save changes to apply.
 					</span>
-					<button type="button" class="btn preset-tonal-primary btn-sm" onclick={discardAvatar}>
-						Discard
-					</button>
+					<Button variant="tonal" color="primary" size="sm" onclick={discardAvatar}>Discard</Button>
 				</div>
 			{/if}
 		</div>
@@ -354,17 +346,16 @@
 							</div>
 						</div>
 						{#if !session.isCurrent}
-							<button
-								type="button"
-								class="btn preset-tonal-error btn-sm"
+							<Button
+								variant="tonal"
+								color="error"
+								size="sm"
+								loading={revokingId === session.id}
 								disabled={revokingId === session.id}
 								onclick={() => revokeSession(session.id)}
 							>
-								{#if revokingId === session.id}
-									<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-								{/if}
 								Revoke
-							</button>
+							</Button>
 						{/if}
 					</div>
 				{/each}

--- a/client/src/routes/(app)/search/+page.svelte
+++ b/client/src/routes/(app)/search/+page.svelte
@@ -5,6 +5,8 @@
 	import type { GalleryGroup } from '$lib/utils/gallery-types';
 	import type { GlobalSearchResponse, GlobalSearchResult, LibraryFile } from '$lib/types/api';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import PageHeader from '$lib/components/ui/PageHeader.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import JustifiedGallery from '$lib/components/JustifiedGallery.svelte';
 	import FilePreview from '$lib/components/FilePreview.svelte';
 
@@ -129,6 +131,13 @@
 </script>
 
 <div class="min-h-0 w-full flex-1 space-y-6 overflow-y-auto px-0.5">
+	<PageHeader
+		title="Search"
+		description={activeQuery.length >= MIN_QUERY_LENGTH
+			? `Results for “${activeQuery}”`
+			: 'Search across all your libraries.'}
+	/>
+
 	{#if results.length}
 		<div class="flex flex-wrap items-center gap-2 text-xs text-surface-500">
 			<span class="rounded bg-surface-200-800 px-2 py-0.5 font-medium">
@@ -165,12 +174,11 @@
 			</div>
 		</div>
 	{:else if !results.length}
-		<div
-			class="flex items-center gap-3 rounded-lg bg-surface-200-800 px-4 py-3 text-sm text-surface-500"
-		>
-			<AppIcon name={ICONS.folder} class="size-5 shrink-0" />
-			<span>No results found for “{activeQuery}”.</span>
-		</div>
+		<EmptyState
+			icon={ICONS.search}
+			title="No results found"
+			description={`Nothing matched “${activeQuery}”. Try a different term.`}
+		/>
 	{:else}
 		<div>
 			<JustifiedGallery groups={galleryGroups} onselect={openPreview} />

--- a/client/src/routes/(app)/search/page.svelte.test.ts
+++ b/client/src/routes/(app)/search/page.svelte.test.ts
@@ -114,7 +114,8 @@ describe('search/+page.svelte', () => {
 		const screen = render(SearchPage);
 		await vi.waitFor(() => expect(mocks.searchQuery).toHaveBeenCalled());
 
-		await expect.element(screen.getByText(/No results found for/)).toBeInTheDocument();
+		await expect.element(screen.getByText('No results found')).toBeInTheDocument();
+		await expect.element(screen.getByText(/Nothing matched/)).toBeInTheDocument();
 	});
 
 	it('shows the error state when the search request fails', async () => {

--- a/client/src/routes/invites/[token]/+page.svelte
+++ b/client/src/routes/invites/[token]/+page.svelte
@@ -9,6 +9,7 @@
 	import { toast } from '$lib/state/toast';
 	import { ICONS } from '$lib/utils/icons';
 	import AppIcon from '$lib/components/ui/AppIcon.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import UserAvatar from '$lib/components/ui/UserAvatar.svelte';
 	import AuthCardShell from '$lib/components/ui/AuthCardShell.svelte';
 	import type { InviteLookupResponse } from '$lib/types/api';
@@ -126,25 +127,18 @@
 
 			<div class="flex flex-wrap items-center gap-2">
 				{#if invite?.canAccept}
-					<button
-						type="button"
-						class="btn preset-filled-primary-500"
-						disabled={accepting}
-						onclick={acceptInvite}
-					>
-						{#if accepting}
-							<AppIcon name={ICONS.loading} class="size-4 animate-spin" />
-						{:else}
+					<Button loading={accepting} disabled={accepting} onclick={acceptInvite}>
+						{#snippet icon()}
 							<AppIcon name={ICONS.check} class="size-4" />
-						{/if}
+						{/snippet}
 						Accept Invite
-					</button>
+					</Button>
 				{/if}
 				{#if invite?.library.id}
-					<a href={`/libraries/${invite.library.id}`} class="btn preset-tonal-surface">
+					<Button href={`/libraries/${invite.library.id}`} variant="tonal" color="surface">
 						Go to library
 						<AppIcon name={ICONS.arrowRight} class="size-4" />
-					</a>
+					</Button>
 				{/if}
 			</div>
 		{/if}


### PR DESCRIPTION
A focused, app-wide UI consistency + polish pass. Adopts the design-system primitives that already existed (`Button`, `Card`, `AppPanel`), adds two missing ones (`PageHeader`, `EmptyState`), and closes the a11y gaps a codebase survey turned up. No behavioral changes beyond the intended UI/UX.

## What changed (the 10 improvements)

**A11y & correctness**
1. **Queue purge** now uses the styled `ConfirmModal` instead of a native `window.confirm()` (the only one in the app).
2. **`AppIcon`** is `aria-hidden` by default (decorative); overridable for standalone labelled icons.
3. **Keyboard a11y**: list-view rows are now `role=button` + Enter/Space (mirroring the grid card); focus-visible rings on card/row/notification targets; `aria-label`s on the admin job filters.
4. **`FilePreview` lightbox** gets focus-on-open, focus restore, and a Tab focus-trap.

**Structure & states**
5. **New `PageHeader`** — one page-title treatment, applied to admin / search / notifications; removed the redundant double-title bars on Feed/Map (the breadcrumb + sidebar already identify the tab).
6. **New `EmptyState`** — one "nothing here" treatment; routed feed, notifications, search (fixes the wrong folder→search icon), objects, people, people-detail and admin-users through it.
7. **Load errors ≠ empty results** — objects, admin (stats/settings/users), and the sidebar now show a distinct error state with retry instead of masquerading as empty/"—".

**Design-system consolidation**
8. **Adopt the `Button` primitive** — migrated ~70 raw `btn preset-*` buttons across 21 files to `<Button>` (byte-equivalent classes; dog-fooded in `ConfirmModal`/`OAuthGoogleButton`/`LibraryEmptyState`). Dynamic-preset / bare `preset-tonal` buttons left raw where the primitive can't reproduce them 1:1.
9. **Unify popover surfaces** — all 8 elevated popovers now share one recipe matching `Card` tone="elevated" (`rounded-lg` + border + `preset-filled-surface-100-900` + `shadow-xl`), fixing the md/lg/xl radius drift.
10. **Muted-text token** aligned to `text-surface-600-400` in the shared primitives (StatCard, AppModal, ConfirmModal); fixed the missing `min-h-0` on the tags page.

This also folds in an earlier admin panel/card unification (shared `StatCard` + `AppPanel` for the dashboard and jobs view).

## Scope notes / deliberate deferrals
- **Popovers** were normalized to the canonical elevated *class recipe* rather than wrapped in the `Card` component — `Card`'s inner padding wrapper breaks the menus' `space-y`/`flex` layouts. The rendered surface matches `Card` tone="elevated" exactly.
- **Muted-text**: aligned the primitives (the survey's recommended first step); a full repo-wide `text-surface-500` sweep and extracting a shared `PageShell` wrapper are left as follow-ups (broad churn, low visual delta, and a `PageShell` for settings would collide with #615).
- Settings full-width (#615) is intentionally a separate PR; this branch is off `main`.

## Verification
- `bun run typecheck` — 0 errors / 0 warnings
- `bun run lint` (prettier + eslint) — clean
- `bun run test:unit` — **1632 pass** (134 files; +11 new tests for PageHeader, EmptyState, AppIcon, the sidebar/objects/admin error states)
- Playwright functional e2e (real seeded stack) — **12/12 pass**
- Visual spot-checks: admin, search empty state, notifications (screenshots reviewed)