### PR TITLE
fix(backend): guard media-job completion against mid-run version bumps

### DIFF
--- a/backend/internal/services/audiodetection/db_test.go
+++ b/backend/internal/services/audiodetection/db_test.go
@@ -2,6 +2,7 @@ package audiodetection
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,6 +87,115 @@ func TestSetStateAndFail_DB(t *testing.T) {
 	}
 	if f.AudioDetectError == nil || *f.AudioDetectError == "" {
 		t.Errorf("error message not recorded: %v", f.AudioDetectError)
+	}
+}
+
+func TestComplete_MatchingVersionReplacesDetections(t *testing.T) {
+	db := audioTestDB(t)
+	libID, fileID := seedAudioFile(t, db, "audio/wav")
+	h := NewTaskHandler(db, nil, &config.Config{}, nil)
+
+	// Simulate a reprocess: a version-1 run already completed (one persisted
+	// detection), then the trigger bumped audio_detect_version to 2 and the
+	// version-2 run is now finishing.
+	if err := db.Model(&models.File{}).Where("id = ?", fileID).Updates(map[string]interface{}{
+		"audio_detect_version":   2,
+		"audio_detected_version": 1,
+	}).Error; err != nil {
+		t.Fatalf("seed versions: %v", err)
+	}
+	old := models.AudioDetection{FileID: fileID, LibraryID: libID, Label: "Music", ClassIndex: 137, Score: 0.5, StartSeconds: 0, EndSeconds: 1, Version: 1}
+	if err := db.Create(&old).Error; err != nil {
+		t.Fatalf("seed old detection: %v", err)
+	}
+
+	dets := []models.AudioDetection{{FileID: fileID, LibraryID: libID, Label: "Speech", ClassIndex: 0, Score: 0.9, StartSeconds: 0, EndSeconds: 2, Version: 2}}
+	if err := h.complete(fileID, 2, dets, DefaultModelID); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	var f models.File
+	if err := db.Where("id = ?", fileID).First(&f).Error; err != nil {
+		t.Fatalf("reload file: %v", err)
+	}
+	if f.AudioDetectStatus == nil || *f.AudioDetectStatus != "ready" {
+		t.Errorf("audio_detect_status = %v, want ready", f.AudioDetectStatus)
+	}
+	// The worker must never bump audio_detect_version — the trigger side owns it.
+	if f.AudioDetectVersion != 2 {
+		t.Errorf("audio_detect_version = %d, want 2 (unchanged)", f.AudioDetectVersion)
+	}
+	if f.AudioDetectedVersion == nil || *f.AudioDetectedVersion != 2 {
+		t.Errorf("audio_detected_version = %v, want 2", f.AudioDetectedVersion)
+	}
+	if f.AudioDetectModel == nil || *f.AudioDetectModel != DefaultModelID {
+		t.Errorf("audio_detect_model = %v, want %s", f.AudioDetectModel, DefaultModelID)
+	}
+
+	var got []models.AudioDetection
+	if err := db.Where("file_id = ?", fileID).Find(&got).Error; err != nil {
+		t.Fatalf("query detections: %v", err)
+	}
+	if len(got) != 1 || got[0].Label != "Speech" || got[0].Version != 2 {
+		t.Errorf("detections = %+v, want one Speech row at version 2", got)
+	}
+}
+
+func TestComplete_SupersededRollsBackStaleWork(t *testing.T) {
+	db := audioTestDB(t)
+	libID, fileID := seedAudioFile(t, db, "audio/wav")
+	h := NewTaskHandler(db, nil, &config.Config{}, nil)
+
+	// A version-1 run is in flight when a reprocess lands: the trigger bumps
+	// audio_detect_version to 2 and resets the status to queued. The stale
+	// run's completion (targeting version 1) must roll back wholesale.
+	if err := db.Model(&models.File{}).Where("id = ?", fileID).Updates(map[string]interface{}{
+		"audio_detect_status":    "queued",
+		"audio_detect_progress":  0,
+		"audio_detect_version":   2,
+		"audio_detected_version": 1,
+	}).Error; err != nil {
+		t.Fatalf("seed versions: %v", err)
+	}
+	keep := models.AudioDetection{FileID: fileID, LibraryID: libID, Label: "Music", ClassIndex: 137, Score: 0.5, StartSeconds: 0, EndSeconds: 1, Version: 1}
+	if err := db.Create(&keep).Error; err != nil {
+		t.Fatalf("seed existing detection: %v", err)
+	}
+
+	stale := []models.AudioDetection{{FileID: fileID, LibraryID: libID, Label: "Speech", ClassIndex: 0, Score: 0.9, StartSeconds: 0, EndSeconds: 2, Version: 1}}
+	err := h.complete(fileID, 1, stale, DefaultModelID)
+	// run() maps errSuperseded to a clean nil return (no fail()): the discard
+	// is logged, never surfaced as a job failure.
+	if !errors.Is(err, errSuperseded) {
+		t.Fatalf("complete = %v, want errSuperseded", err)
+	}
+
+	// The fresh job's queued state and versions must be untouched.
+	var f models.File
+	if err := db.Where("id = ?", fileID).First(&f).Error; err != nil {
+		t.Fatalf("reload file: %v", err)
+	}
+	if f.AudioDetectStatus == nil || *f.AudioDetectStatus != "queued" {
+		t.Errorf("audio_detect_status = %v, want queued (untouched)", f.AudioDetectStatus)
+	}
+	if f.AudioDetectVersion != 2 {
+		t.Errorf("audio_detect_version = %d, want 2 (untouched)", f.AudioDetectVersion)
+	}
+	if f.AudioDetectedVersion == nil || *f.AudioDetectedVersion != 1 {
+		t.Errorf("audio_detected_version = %v, want 1 (untouched)", f.AudioDetectedVersion)
+	}
+	if f.AudioDetectModel != nil {
+		t.Errorf("audio_detect_model = %v, want nil (untouched)", f.AudioDetectModel)
+	}
+
+	// The delete+insert must have rolled back with the guard miss: the
+	// existing detection survives, the stale rows never land.
+	var got []models.AudioDetection
+	if err := db.Where("file_id = ?", fileID).Find(&got).Error; err != nil {
+		t.Fatalf("query detections: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != keep.ID || got[0].Label != "Music" || got[0].Version != 1 {
+		t.Errorf("detections = %+v, want the original Music row at version 1", got)
 	}
 }
 

--- a/backend/internal/services/audiodetection/worker.go
+++ b/backend/internal/services/audiodetection/worker.go
@@ -283,7 +283,7 @@ func (h *TaskHandler) run(ctx context.Context, libraryID, fileID string) error {
 				Score:        probs[idx],
 				StartSeconds: windowStart,
 				EndSeconds:   windowEnd,
-				Version:      targetVersion + 1,
+				Version:      targetVersion,
 			})
 		}
 
@@ -291,38 +291,62 @@ func (h *TaskHandler) run(ctx context.Context, libraryID, fileID string) error {
 		h.setState(fileID, ptr("processing"), &progress, nil, nil)
 	}
 
-	// Persist in a transaction: bump version, delete old detections, insert new.
-	newVersion := targetVersion + 1
-	err = h.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("file_id = ?", file.ID).Delete(&models.AudioDetection{}).Error; err != nil {
-			return err
+	// Apply the results only if a concurrent reprocess hasn't bumped the
+	// version out from under us — complete's guarded transaction makes the
+	// check-and-write atomic, so a stale run can never clobber a fresh job's
+	// detections or freshly-queued status.
+	if err := h.complete(file.ID, targetVersion, detections, spec.ID); err != nil {
+		if errors.Is(err, errSuperseded) {
+			log.Printf("audio-detect: version moved on, discarding stale work for file %s", fileID)
+			return nil
 		}
-		if len(detections) > 0 {
-			for i := range detections {
-				detections[i].Version = newVersion
-				detections[i].ID = uuid.Nil
-			}
-			if err := tx.Create(&detections).Error; err != nil {
-				return err
-			}
-		}
-		return tx.Model(&models.File{}).Where("id = ?", file.ID).Updates(map[string]interface{}{
-			"audio_detect_status":      "ready",
-			"audio_detect_progress":    100,
-			"audio_detect_eta_seconds": nil,
-			"audio_detect_error":       nil,
-			"audio_detect_version":     newVersion,
-			"audio_detected_version":   newVersion,
-			"audio_detect_model":       spec.ID,
-		}).Error
-	})
-	if err != nil {
 		h.fail(fileID, fmt.Errorf("persist detections: %w", err))
 		return err
 	}
 
 	log.Printf("audio-detect: file %s complete (%d detections)", fileID, len(detections))
 	return nil
+}
+
+// errSuperseded signals that audio_detect_version moved on while a run was in
+// flight (a reprocess was queued mid-run); returning it from inside complete's
+// transaction rolls the detections delete+insert back along with the file
+// update, so the stale results vanish without a trace.
+var errSuperseded = errors.New("audio detect version superseded")
+
+// complete replaces the file's detections and marks the job ready in a single
+// transaction, but only if audio_detect_version still equals the version this
+// run started from. The trigger side owns bumping audio_detect_version (the
+// worker never touches it); a reprocess bumps the version, so the guard turns
+// stale work into a no-op atomically (no read-then-write race).
+func (h *TaskHandler) complete(fileID uuid.UUID, targetVersion int, detections []models.AudioDetection, modelID string) error {
+	return h.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("file_id = ?", fileID).Delete(&models.AudioDetection{}).Error; err != nil {
+			return err
+		}
+		if len(detections) > 0 {
+			if err := tx.Create(&detections).Error; err != nil {
+				return err
+			}
+		}
+		res := tx.Model(&models.File{}).
+			Where("id = ? AND audio_detect_version = ?", fileID, targetVersion).
+			Updates(map[string]interface{}{
+				"audio_detect_status":      "ready",
+				"audio_detect_progress":    100,
+				"audio_detect_eta_seconds": nil,
+				"audio_detect_error":       nil,
+				"audio_detected_version":   targetVersion,
+				"audio_detect_model":       modelID,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return errSuperseded
+		}
+		return nil
+	})
 }
 
 func (h *TaskHandler) copySourceToTemp(libraryID, fileID, dst string) error {

--- a/backend/internal/services/momentexport/worker.go
+++ b/backend/internal/services/momentexport/worker.go
@@ -113,8 +113,9 @@ func (h *TaskHandler) processMoment(ctx context.Context, libraryID, fileID, mome
 		return err
 	}
 
-	// 5. Re-check export_version. If the user edited the range during transcode,
-	// this encode is stale — discard and bail.
+	// 5. Cheap early-out before the cache upload: if the user edited the range
+	// during transcode this encode is already stale. The authoritative check is
+	// the guarded complete() below — this read is only an optimization.
 	var fresh models.Moment
 	if err := h.db.Where("id = ?", momentID).First(&fresh).Error; err != nil {
 		h.fail(momentID, "reload: %v", err)
@@ -139,12 +140,31 @@ func (h *TaskHandler) processMoment(ctx context.Context, libraryID, fileID, mome
 		return err
 	}
 
-	// 7. Mark ready.
-	complete := 100
-	exported := runVersion
-	h.setExportState(momentID, stringPtr("ready"), &complete, nil, &exported)
-	log.Printf("moment:export — completed moment=%s version=%d", momentID, runVersion)
+	// 7. Mark ready — guarded, so an edit landing after the step-5 check still
+	// can't be clobbered with stale state.
+	if h.complete(momentID, runVersion) {
+		log.Printf("moment:export — completed moment=%s version=%d", momentID, runVersion)
+	} else {
+		log.Printf("moment:export — stale version (ran=%d); discarding", runVersion)
+	}
 	return nil
+}
+
+// complete marks the export ready, but only if export_version still equals the
+// version this run satisfied. An edit bumps the version, so the guard turns
+// stale work into a no-op atomically (no read-then-write race). Returns true
+// when the row was updated.
+func (h *TaskHandler) complete(momentID string, version int) bool {
+	res := h.db.Model(&models.Moment{}).
+		Where("id = ? AND export_version = ?", momentID, version).
+		Updates(map[string]interface{}{
+			"export_status":      "ready",
+			"export_progress":    100,
+			"export_eta_seconds": nil,
+			"exported_version":   version,
+			"updated_at":         time.Now(),
+		})
+	return res.Error == nil && res.RowsAffected > 0
 }
 
 func (h *TaskHandler) setExportState(momentID string, status *string, progress *int, eta *int, exportedVersion *int) {

--- a/backend/internal/services/momentexport/worker_test.go
+++ b/backend/internal/services/momentexport/worker_test.go
@@ -299,6 +299,47 @@ func TestProcessMoment_AlreadyExported(t *testing.T) {
 	}
 }
 
+func TestComplete_VersionGuard(t *testing.T) {
+	db := setupTestDB(t)
+	_, _, momentID := seedMoment(t, db, 0, 1, 2)
+	h := &TaskHandler{db: db}
+
+	// An edit bumped export_version to 3 while the version-2 run was in flight.
+	if err := db.Model(&models.Moment{}).Where("id = ?", momentID).Update("export_version", 3).Error; err != nil {
+		t.Fatalf("bump version: %v", err)
+	}
+	if h.complete(momentID.String(), 2) {
+		t.Fatal("complete should refuse a stale version")
+	}
+	var m models.Moment
+	if err := db.First(&m, "id = ?", momentID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if m.ExportStatus != nil && *m.ExportStatus == "ready" {
+		t.Fatal("stale complete must not mark ready")
+	}
+	if m.ExportedVersion != nil {
+		t.Fatalf("stale complete must not stamp exported_version, got %d", *m.ExportedVersion)
+	}
+
+	// Matching version persists.
+	if !h.complete(momentID.String(), 3) {
+		t.Fatal("complete should persist for the current version")
+	}
+	if err := db.First(&m, "id = ?", momentID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if m.ExportStatus == nil || *m.ExportStatus != "ready" {
+		t.Fatal("expected export_status ready")
+	}
+	if m.ExportProgress == nil || *m.ExportProgress != 100 {
+		t.Fatal("expected export_progress 100")
+	}
+	if m.ExportedVersion == nil || *m.ExportedVersion != 3 {
+		t.Fatal("expected exported_version 3")
+	}
+}
+
 func TestProcessMoment_InvalidRange(t *testing.T) {
 	db := setupTestDB(t)
 	store := setupTestStorage(t)

--- a/backend/internal/services/transcribe/worker.go
+++ b/backend/internal/services/transcribe/worker.go
@@ -176,19 +176,16 @@ func (h *TaskHandler) run(ctx context.Context, libraryID, fileID string) error {
 	txtBytes, _ := os.ReadFile(outBase + ".txt")
 	vttBytes, _ := os.ReadFile(outBase + ".vtt")
 
-	// 6. Persist.
-	updates := map[string]interface{}{
-		"transcribe_status":      "ready",
-		"transcribe_progress":    100,
-		"transcribe_eta_seconds": nil,
-		"transcribe_error":       nil,
-		"transcribed_version":    targetVersion,
-		"transcript_text":        strings.TrimSpace(string(txtBytes)),
-		"transcript_vtt":         string(vttBytes),
-		"transcript_model":       modelName,
-	}
-	if err := h.db.Model(&models.File{}).Where("id = ?", fileID).Updates(updates).Error; err != nil {
+	// 6. Persist — but only if a concurrent reprocess hasn't bumped the version
+	// out from under us. The guarded UPDATE makes the check-and-write atomic, so
+	// a reprocess landing mid-whisper-run can never be clobbered by stale results.
+	updated, err := h.complete(fileID, targetVersion, strings.TrimSpace(string(txtBytes)), string(vttBytes), modelName)
+	if err != nil {
 		return fmt.Errorf("persist transcript: %w", err)
+	}
+	if !updated {
+		log.Printf("transcribe: version moved on, discarding stale work for file %s", fileID)
+		return nil
 	}
 	log.Printf("transcribe: done for file %s (%d chars)", fileID, len(txtBytes))
 
@@ -245,6 +242,30 @@ func (h *TaskHandler) setState(fileID string, status *string, progress *int, eta
 func (h *TaskHandler) fail(fileID string, err error) {
 	msg := err.Error()
 	h.setState(fileID, stringPtr("failed"), nil, nil, &msg)
+}
+
+// complete writes the finished transcript, but only if transcribe_version still
+// equals the version this run started from. A reprocess bumps the version, so
+// the guard turns stale work into a no-op atomically (no read-then-write race).
+// Returns whether the row was updated; a DB error is surfaced separately so the
+// caller can let asynq retry rather than discarding the finished transcript.
+func (h *TaskHandler) complete(fileID string, version int, text, vtt, modelName string) (bool, error) {
+	res := h.db.Model(&models.File{}).
+		Where("id = ? AND transcribe_version = ?", fileID, version).
+		Updates(map[string]interface{}{
+			"transcribe_status":      "ready",
+			"transcribe_progress":    100,
+			"transcribe_eta_seconds": nil,
+			"transcribe_error":       nil,
+			"transcribed_version":    version,
+			"transcript_text":        text,
+			"transcript_vtt":         vtt,
+			"transcript_model":       modelName,
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected > 0, nil
 }
 
 func stringPtr(s string) *string { return &s }

--- a/backend/internal/services/transcribe/worker_run_test.go
+++ b/backend/internal/services/transcribe/worker_run_test.go
@@ -623,6 +623,68 @@ func TestFail_SetsFailedStatusAndMessage(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// complete — version guard
+// ---------------------------------------------------------------------------
+
+// TestComplete_VersionGuard ensures a reprocess landing mid-whisper-run can't
+// be clobbered: complete() with a superseded version must discard the stale
+// transcript, and with the matching version must persist it.
+func TestComplete_VersionGuard(t *testing.T) {
+	db := workerDB(t)
+	_, fileID := seedFile(t, db, "audio/wav")
+	// Simulate a reprocess landing mid-run: the row's version moved to 1 while
+	// this worker captured targetVersion 0 at start.
+	if err := db.Model(&models.File{}).Where("id = ?", fileID).Update("transcribe_version", 1).Error; err != nil {
+		t.Fatalf("bump version: %v", err)
+	}
+	h := &TaskHandler{db: db}
+
+	// Stale version → no-op.
+	updated, err := h.complete(fileID.String(), 0, "stale text", "stale vtt", "tiny")
+	if err != nil {
+		t.Fatalf("complete() stale: %v", err)
+	}
+	if updated {
+		t.Fatal("complete() with a stale version should return false")
+	}
+	var afterStale models.File
+	db.Where("id = ?", fileID).First(&afterStale)
+	if afterStale.TranscribeStatus != nil || afterStale.TranscriptText != nil || afterStale.TranscribedVersion != nil {
+		t.Fatalf("stale complete() wrote data: status=%v text=%v transcribed=%v",
+			afterStale.TranscribeStatus, afterStale.TranscriptText, afterStale.TranscribedVersion)
+	}
+
+	// Matching version → applied.
+	updated, err = h.complete(fileID.String(), 1, "fresh text", "WEBVTT fresh", "tiny")
+	if err != nil {
+		t.Fatalf("complete() matching: %v", err)
+	}
+	if !updated {
+		t.Fatal("complete() with the matching version should return true")
+	}
+	var afterMatch models.File
+	db.Where("id = ?", fileID).First(&afterMatch)
+	if afterMatch.TranscribeStatus == nil || *afterMatch.TranscribeStatus != "ready" {
+		t.Errorf("status = %v, want ready", afterMatch.TranscribeStatus)
+	}
+	if afterMatch.TranscribeProgress == nil || *afterMatch.TranscribeProgress != 100 {
+		t.Errorf("progress = %v, want 100", afterMatch.TranscribeProgress)
+	}
+	if afterMatch.TranscribedVersion == nil || *afterMatch.TranscribedVersion != 1 {
+		t.Errorf("transcribed_version = %v, want 1", afterMatch.TranscribedVersion)
+	}
+	if afterMatch.TranscriptText == nil || *afterMatch.TranscriptText != "fresh text" {
+		t.Errorf("transcript text = %v", afterMatch.TranscriptText)
+	}
+	if afterMatch.TranscriptVTT == nil || *afterMatch.TranscriptVTT != "WEBVTT fresh" {
+		t.Errorf("transcript vtt = %v", afterMatch.TranscriptVTT)
+	}
+	if afterMatch.TranscriptModel == nil || *afterMatch.TranscriptModel != "tiny" {
+		t.Errorf("transcript model = %v", afterMatch.TranscriptModel)
+	}
+}
+
 func TestStringPtrIntPtr(t *testing.T) {
 	if *stringPtr("z") != "z" {
 		t.Error("stringPtr")

--- a/backend/internal/services/transcribe/worker_test.go
+++ b/backend/internal/services/transcribe/worker_test.go
@@ -55,7 +55,7 @@ func TestProcessTask_RejectsInvalidPayload(t *testing.T) {
 
 func TestTimestampRegex_ParsesSegmentEnd(t *testing.T) {
 	cases := []struct {
-		line   string
+		line    string
 		wantSec float64
 	}{
 		{"[00:00:00.000 --> 00:00:02.140]   we don't use the hardware", 2.14},

--- a/backend/internal/services/waveform/worker.go
+++ b/backend/internal/services/waveform/worker.go
@@ -100,7 +100,9 @@ func (h *TaskHandler) run(ctx context.Context, libraryID, fileID string) error {
 	}
 	if !hasAudio {
 		h.storeEmptyWaveform(libraryID, fileID)
-		h.complete(fileID, targetVersion, defaultPeaksPerSecond)
+		if !h.complete(fileID, targetVersion, defaultPeaksPerSecond) {
+			log.Printf("waveform: version moved on, discarding stale work for file %s", fileID)
+		}
 		return nil
 	}
 
@@ -130,24 +132,22 @@ func (h *TaskHandler) run(ctx context.Context, libraryID, fileID string) error {
 		h.fail(fileID, fmt.Errorf("marshal waveform: %w", err))
 		return err
 	}
+	// The cache blob is not version-guarded: a stale job may overwrite it, but
+	// the newer in-flight job rewrites it on its own completion.
 	cacheKey := storage.WaveformKey(libraryID, fileID)
 	if err := h.storage.StoreCacheBuffer(cacheKey, jsonBytes); err != nil {
 		h.fail(fileID, fmt.Errorf("store waveform cache: %w", err))
 		return err
 	}
 
-	// Verify we haven't been superseded
-	var current models.File
-	if err := h.db.Where("id = ?", fileID).First(&current).Error; err != nil {
-		return err
+	// Apply the result only if a concurrent regeneration hasn't bumped the
+	// version out from under us. The guarded UPDATE makes the check-and-write
+	// atomic, so a regeneration landing mid-run can never leave stale data behind.
+	if h.complete(fileID, targetVersion, defaultPeaksPerSecond) {
+		log.Printf("waveform: complete for file %s (%d peaks)", fileID, len(peaks))
+	} else {
+		log.Printf("waveform: version moved on, discarding stale work for file %s", fileID)
 	}
-	if current.WaveformVersion != targetVersion {
-		log.Printf("waveform: version changed (%d → %d), discarding work for file %s", targetVersion, current.WaveformVersion, fileID)
-		return nil
-	}
-
-	h.complete(fileID, targetVersion, defaultPeaksPerSecond)
-	log.Printf("waveform: complete for file %s (%d peaks)", fileID, len(peaks))
 	return nil
 }
 
@@ -308,16 +308,25 @@ func (h *TaskHandler) fail(fileID string, err error) {
 	h.setState(fileID, stringPtr("failed"), nil, &msg)
 }
 
-func (h *TaskHandler) complete(fileID string, version int, peaksPerSec int) {
+// complete marks the waveform ready, but only if waveform_version still equals
+// the version this run started from. A regeneration bumps the version, so the
+// guard turns stale work into a no-op atomically (no read-then-write race).
+// Returns true when the row was updated.
+func (h *TaskHandler) complete(fileID string, version int, peaksPerSec int) bool {
 	ready := "ready"
 	full := 100
-	h.db.Model(&models.File{}).Where("id = ?", fileID).Updates(map[string]interface{}{
-		"waveform_status":           ready,
-		"waveform_progress":         full,
-		"waveform_error":            nil,
-		"waveformed_version":        version,
-		"waveform_peaks_per_second": peaksPerSec,
-	})
+	res := h.db.Model(&models.File{}).
+		Where("id = ? AND waveform_version = ?", fileID, version).
+		Updates(map[string]interface{}{
+			"waveform_status":           ready,
+			"waveform_progress":         full,
+			"waveform_error":            nil,
+			"waveformed_version":        version,
+			"waveform_peaks_per_second": peaksPerSec,
+		})
+	if res.Error != nil || res.RowsAffected == 0 {
+		return false
+	}
 
 	if h.activitySvc != nil {
 		var f models.File
@@ -336,6 +345,7 @@ func (h *TaskHandler) complete(fileID string, version int, peaksPerSec int) {
 			})
 		}
 	}
+	return true
 }
 
 func stringPtr(s string) *string { return &s }

--- a/backend/internal/services/waveform/worker_extra_test.go
+++ b/backend/internal/services/waveform/worker_extra_test.go
@@ -419,6 +419,49 @@ func TestComplete(t *testing.T) {
 	}
 }
 
+// TestComplete_StaleVersionDiscarded is the regression test for the
+// supersession race: a regeneration that bumps waveform_version while a job is
+// in flight must make the stale job's complete() a no-op, while a job running
+// at the current version persists normally.
+func TestComplete_StaleVersionDiscarded(t *testing.T) {
+	db := setupTestDB(t)
+	libID, ownerID := seedLibrary(t, db)
+	f := models.File{BaseModel: models.BaseModel{ID: uuid.New()}, LibraryID: libID, Name: "a.wav", MimeType: "audio/wav", OwnerID: &ownerID, WaveformVersion: 3}
+	if err := db.Create(&f).Error; err != nil {
+		t.Fatal(err)
+	}
+	h := NewTaskHandler(db, nil, testConfig(), nil)
+
+	// Simulate TriggerWaveform landing mid-run: bump the version to 4 while a
+	// job captured at version 3 is still in flight.
+	if err := db.Model(&models.File{}).Where("id = ?", f.ID).Update("waveform_version", 4).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if h.complete(f.ID.String(), 3, defaultPeaksPerSecond) {
+		t.Fatalf("expected complete to discard stale work for version 3")
+	}
+	var updated models.File
+	db.Where("id = ?", f.ID).First(&updated)
+	if updated.WaveformStatus != nil {
+		t.Fatalf("stale job set waveform_status: %v", *updated.WaveformStatus)
+	}
+	if updated.WaveformedVersion != nil {
+		t.Fatalf("stale job set waveformed_version: %v", *updated.WaveformedVersion)
+	}
+
+	if !h.complete(f.ID.String(), 4, defaultPeaksPerSecond) {
+		t.Fatalf("expected complete to persist for matching version 4")
+	}
+	db.Where("id = ?", f.ID).First(&updated)
+	if updated.WaveformStatus == nil || *updated.WaveformStatus != "ready" {
+		t.Fatalf("status not ready: %v", updated.WaveformStatus)
+	}
+	if updated.WaveformedVersion == nil || *updated.WaveformedVersion != 4 {
+		t.Fatalf("waveformed_version not set: %v", updated.WaveformedVersion)
+	}
+}
+
 func TestStoreEmptyWaveform(t *testing.T) {
 	store := setupTestStorage(t)
 	h := NewTaskHandler(nil, store, testConfig(), nil)


### PR DESCRIPTION
## What

Fixes the same supersession race in four async media workers. A reprocess request bumps a File job's `*_version` column and re-enqueues while an older job may still be in flight; these workers let the stale run clobber the fresh job's state on completion:

| Worker | Bug |
|---|---|
| `transcribe` | Final persist had **no version guard at all** — stale whisper output overwrote the transcript, marked the job `ready`, and stamped `transcribed_version` with the old version |
| `waveform` | Non-atomic read-then-check-then-write — a `TriggerWaveform` landing between the `First` re-read and the write was lost; the stale-completion path also emitted a bogus "waveform ready" activity event |
| `audiodetection` | Worker bumped `audio_detect_version` itself to `targetVersion+1` on completion (inverting the trigger-owns-the-bump convention every other job kind uses) with no guard — a stale run deleted and replaced the fresh job's detections wholesale. Also removed dead code double-stamping detection-row `Version` |
| `momentexport` | Re-checked `export_version` after transcode but *before* the cache upload, then marked `ready` unguarded — an edit landing during the upload was clobbered |

## How

All four now follow `metadata/worker.go`'s canonical pattern: an atomic guarded `UPDATE … WHERE id = ? AND <prefix>_version = ?` with a `RowsAffected` check, logging `version moved on, discarding stale work` on a miss. Two deliberate variations:

- **audiodetection** runs the guard inside its existing transaction and returns an `errSuperseded` sentinel so the detections delete+insert roll back along with the file update — stale results vanish without a trace.
- **transcribe** surfaces a persist-time DB error separately from a guard miss, so a transient DB blip still triggers an asynq retry instead of silently discarding minutes of whisper compute (the pre-fix behavior).

The trigger side (`mediajobs`) is untouched — it already owned the version bump correctly.

## Verification

- Regression tests added for each guard (stale version → no-op + state untouched; matching version → persisted), all confirmed running against the real test postgres (no skips). The audiodetection test also proves the transaction rollback: a pre-existing detection survives a superseded completion with its original ID.
- Audited every non-test reader of `transcribe(d)_version`, `waveform(ed)_version`, `audio_detect(ed)_version`, `export(ed)_version` (handlers serializers, seed, mediajobs, client types) — none depend on the old semantics; the API JSON shape is unchanged.
- `go test ./... -race -count=1` green across all 40 packages; `gofmt`/`go vet` clean.

No frontend changes.