### PR TITLE
docs(website): rewrite docs for accuracy and plain, honest copy

### DIFF
--- a/website/src/components/landing/FAQ.astro
+++ b/website/src/components/landing/FAQ.astro
@@ -14,7 +14,7 @@ const faqs = [
 	},
 	{
 		q: 'How do I run it?',
-		a: 'With Docker and Docker Compose on a single machine, or the Helm chart on Kubernetes. It is designed to run comfortably on modest hardware.',
+		a: 'With Docker Compose on a single machine, or the Helm chart on Kubernetes. No GPU is needed — a machine with a few CPU cores and 8 GB of RAM is plenty to start.',
 	},
 	{
 		q: 'Can I connect my own tools?',

--- a/website/src/content/docs/architecture/backend-architecture-go.md
+++ b/website/src/content/docs/architecture/backend-architecture-go.md
@@ -4,9 +4,10 @@ description: "How the Go API server boots, handles requests, manages async jobs,
 ---
 
 The Alcoves backend is a pure JSON API written in Go. It runs as a single binary
-against PostgreSQL, a Dragonfly/Redis-compatible queue, and either local or S3
-blob storage. It serves no HTML — the Nuxt frontend is a separate process that
-proxies `/api/**` and `/s/**` to this service.
+against PostgreSQL, a Dragonfly/Redis-compatible queue, and local blob storage
+(an S3 driver exists in the codebase but is not wired up yet). It serves no
+HTML — the SvelteKit frontend is a separate process that renders the UI and
+proxies same-origin `/api/**` requests to this service.
 
 If you are contributing a new feature, adding a service, or debugging a
 production issue, this page gives you the mental model you need: how the process
@@ -191,7 +192,7 @@ session:
 
 **Public paths (no session required):**
 - `/api/auth/{login,register,providers,logout,google,google/callback}`
-- `/api/_auth/session` (used by the Nuxt auth guard)
+- `/api/_auth/session` (used by the SvelteKit server to resolve the signed-in user)
 - `/api/share/**` (public moment share)
 - `/api/health`, `/api/version`, `/api/_meta/**`
 - `GET /api/invites/{token}` (invite lookup; the accept POST is guarded inside
@@ -234,7 +235,7 @@ the image/file proxy) call the access service directly and return **404** (not
 | `GET /api/health` | Health check — always available, always public |
 | `GET /api/version` | Build version, commit SHA, build time |
 | `/api/auth/**` | Login, register, logout, session, avatar, Google OAuth |
-| `/api/_auth/session` | Session validation for the Nuxt route guard |
+| `/api/_auth/session` | Session resolution for the SvelteKit server hooks |
 | `/api/libraries` | Library CRUD |
 | `/api/libraries/:id/**` | Files, folders, tags, moments, members, people, objects, downloads, notifications |
 | `/api/invites/**` | Invite lookup (public GET) and accept |

--- a/website/src/content/docs/architecture/overview.md
+++ b/website/src/content/docs/architecture/overview.md
@@ -1,11 +1,11 @@
 ---
 title: Architecture overview
-description: How the Nuxt frontend and the Go (Echo / GORM / Asynq) backend fit together, and how heavy work flows through the async queue.
+description: How the SvelteKit frontend and the Go (Echo / GORM / Asynq) backend fit together, and how heavy work flows through the async queue.
 ---
 
-Alcoves is two deployable units that meet at a reverse proxy: a **Nuxt 4
-frontend** on its own Nitro server, and a **Go API backend**. The Go binary is a
-pure API — it does not embed or serve the frontend.
+Alcoves is two deployable units that meet at a reverse proxy: a **SvelteKit
+frontend** (server-rendered, running under Bun) and a **Go API backend**. The
+Go binary is a pure API — it does not embed or serve the frontend.
 
 This page is the map; the rest of the section drills into each subsystem —
 [backend](/architecture/backend-architecture-go/),
@@ -21,24 +21,28 @@ This page is the map; the rest of the section drills into each subsystem —
                 ┌─────────────────────┐
    browser ───► │   Reverse proxy     │
                 └─────────┬───────────┘
-                          │  /api/**, /s/**
+              /api/**     │     everything else (incl. /s/**)
         ┌─────────────────┴────────────────┐
         ▼                                   ▼
-┌───────────────┐                  ┌──────────────────┐
-│ Nuxt (Nitro)  │                  │  Go API (Echo)    │
-│  :3000        │                  │  :3001            │
-└───────────────┘                  └────────┬─────────┘
-                                            │
-                         ┌──────────────────┼───────────────────┐
-                         ▼                  ▼                    ▼
-                  ┌────────────┐    ┌──────────────┐    ┌────────────────┐
-                  │ PostgreSQL │    │  Dragonfly    │    │ Local / S3      │
-                  │  (GORM)    │    │  (Asynq queue)│    │ blob storage    │
-                  └────────────┘    └──────────────┘    └────────────────┘
+┌──────────────────┐               ┌───────────────┐
+│  Go API (Echo)   │  ◄─SSR/proxy─ │  SvelteKit    │
+│  :3001           │               │  :3000        │
+└────────┬─────────┘               └───────────────┘
+         │
+         ├──────────────────┬───────────────────┐
+         ▼                  ▼                    ▼
+  ┌────────────┐    ┌──────────────┐    ┌────────────────┐
+  │ PostgreSQL │    │  Dragonfly    │    │ Blob storage   │
+  │  (GORM)    │    │  (Asynq queue)│    │ (local disk)   │
+  └────────────┘    └──────────────┘    └────────────────┘
 ```
 
-In production both servers sit behind one reverse proxy; the proxy routes
-`/api/**` and `/s/**` (public share pages) to Go and everything else to Nuxt.
+In production both servers sit behind one reverse proxy. The proxy routes
+`/api/**` to the Go API and everything else — including the public share pages
+at `/s/**` — to SvelteKit. The SvelteKit server also carries an in-process
+`/api` proxy to the Go API, so a single-port setup still works; routing
+`/api/**` directly at the Go API is preferred because it keeps video `Range`
+streaming and resumable uploads untouched.
 
 ## Backend (Go)
 
@@ -46,19 +50,22 @@ In production both servers sit behind one reverse proxy; the proxy routes
   backed by Dragonfly/Redis.
 - **Modes** (`ALCOVES_MODE`): `all`, `api`, or `worker` — the same binary runs
   the request path, the workers, or both.
-- Session auth via an **AES-GCM encrypted cookie**; library access is enforced by
-  middleware before any handler runs.
+- Session auth via an **AES-GCM encrypted cookie**; library access is enforced
+  by middleware before any handler runs.
 - Heavy work — transcoding, hashing, and all ML inference — is pushed onto the
-  queue with status / progress / version columns so it never blocks a request and
-  can be safely re-triggered.
+  queue with status / progress / version columns so it never blocks a request
+  and can be safely re-triggered.
 
-## Frontend (Nuxt 4)
+## Frontend (SvelteKit)
 
-- Nuxt 4 (Vue 3) with the Nuxt UI v4 module, on its own Nitro server.
-- SSR is scoped to `/s/**` (public moment share pages); all other routes are
-  client-rendered to avoid SSR-time backend coupling.
-- An isomorphic fetch wrapper forwards the session cookie on SSR and uses a
-  Nitro proxy on the client.
+- SvelteKit with Svelte 5 runes, Skeleton UI, and Tailwind, built with
+  `adapter-node` and served by Bun.
+- **Server-rendered by default**: every page SSRs against the Go API (never
+  the database) and hydrates in the browser. Share pages emit correct Open
+  Graph tags for link embeds.
+- Server-side fetches forward the session cookie to the Go API; in the
+  browser, binary content and the activity WebSocket can bypass the SvelteKit
+  proxy entirely via `PUBLIC_API_ORIGIN`.
 
 ## The async pipeline
 
@@ -70,6 +77,6 @@ When a file lands, the API enqueues work rather than doing it inline:
    whisper.cpp transcription.
 4. **Index** — results become searchable and drive the activity feed.
 
-This async-by-default design is what keeps the request path fast and the system
-[degradable](/concepts/privacy-and-local-ai/): if an optional dependency is
-missing, Alcoves falls back instead of failing.
+Files are usable as soon as they upload; analysis fills in behind them. The
+queue is weighted so quick, interactive work (image transforms, thumbnails)
+is never starved by long-running transcodes or transcription.

--- a/website/src/content/docs/architecture/storage-backends.md
+++ b/website/src/content/docs/architecture/storage-backends.md
@@ -49,9 +49,10 @@ identifiers (library ID, file ID, user ID) into the scope-qualified keys the
 driver understands. All handlers and media services call the Service, never the
 Driver directly.
 
-**Concrete drivers** — `LocalDriver` (local filesystem, the default) and the S3
-driver (selected by `ALCOVES_STORAGE_DRIVER=s3`). Both are wired at startup;
-the rest of the system never sees the switch.
+**Concrete drivers** — `LocalDriver` (local filesystem, the default) and an S3
+driver. The rest of the system never sees the switch — but note that today the
+server **always constructs the local driver**; the S3 driver and its
+configuration exist in the codebase without being wired into startup yet.
 
 ---
 
@@ -158,11 +159,17 @@ where data stays entirely on your own hardware.
 
 ## S3 driver
 
-When `ALCOVES_STORAGE_DRIVER=s3`, a separate driver implementation backs the
-same interface against any S3-compatible object store (AWS S3, MinIO, Cloudflare
-R2, Backblaze B2, etc.). Because it satisfies the same Driver contract, the
-Service, all handlers, and all media workers behave identically — only the
-destination of the bytes changes.
+:::caution[Not available yet]
+The S3 driver and its `ALCOVES_S3_*` configuration are present in the codebase,
+but the server currently always uses the local driver — setting
+`ALCOVES_STORAGE_DRIVER=s3` has no effect yet. This section describes the
+design so you know where it's headed; treat S3 as planned, not available.
+:::
+
+The S3 driver backs the same interface against any S3-compatible object store
+(AWS S3, MinIO, Cloudflare R2, Backblaze B2, etc.). Because it satisfies the
+same Driver contract, the Service, all handlers, and all media workers behave
+identically — only the destination of the bytes changes.
 
 Each scope maps to a configurable key prefix in the bucket:
 

--- a/website/src/content/docs/concepts/privacy-and-local-ai.md
+++ b/website/src/content/docs/concepts/privacy-and-local-ai.md
@@ -1,57 +1,61 @@
 ---
 title: Privacy & local AI
-description: Why every Alcoves model is CPU-only, how inference stays on your instance, and how the product degrades gracefully.
+description: What runs on your own machine (everything that reads your media), and the few places bytes leave it.
 ---
 
-Privacy in Alcoves is the **default, not a setting**. If a feature would send
-user media or metadata off the instance, it does not ship. All AI inference runs
-locally, on CPU, on hardware you own.
-
-:::note[Sample doc]
-A condensed overview drawn from the repo's
-[ML & runtime inference](https://github.com/rustyguts/alcoves/blob/main/docs/ml-models-and-runtime-inference.md)
-and [models](https://github.com/rustyguts/alcoves/blob/main/docs/models.md) docs.
-:::
+The rule in Alcoves is simple: **anything that reads your files or media runs
+on your own hardware**. Face detection, object labeling, audio tagging, and
+speech transcription are all local, CPU-only inference. There is no cloud API
+in the loop and no GPU requirement.
 
 ## CPU-only by design
 
-Alcoves deliberately targets the no-GPU case. Models are chosen for that
-constraint rather than chasing state-of-the-art at any cost. The practical
-ceiling is roughly **8 GB of RAM** on x86_64.
+Models are chosen to run well on ordinary server CPUs rather than to chase
+benchmark numbers:
 
-| Capability             | Approach                                              |
-| ---------------------- | ---------------------------------------------------- |
-| Face detection + recognition | ONNX models; faces clustered into "people".    |
-| Object detection       | COCO-label object detection (YOLO-class).            |
-| Audio-event tagging    | AudioSet (527 classes).                              |
-| Speech transcription   | whisper.cpp, with admin-selectable model sizes.      |
+| Capability                   | Approach                                          |
+| ---------------------------- | ------------------------------------------------- |
+| Face detection + recognition | ONNX models; faces are clustered into "people".   |
+| Object detection             | YOLO-class object detection (COCO labels).        |
+| Audio-event tagging          | AudioSet classifier (527 sound classes).          |
+| Speech transcription         | whisper.cpp, with admin-selectable model sizes.   |
 
-Models **download on demand** the first time a capability is used — nothing is
-bundled, and **no inference ever leaves the box**.
+Detection models are small (well under 2 GB of working memory). Transcription
+is the heavy one: the default `large-v3` whisper model wants several GB of RAM,
+and the admin panel lets you pick anything down to `tiny` to match your
+hardware. Everything runs in a background job queue, so a slow machine means
+slower indexing — not a slower app.
 
-## No telemetry, ever
+## What does leave your machine
 
-The Go backend is a pure API with no analytics pipeline phoning home — and there
-never will be one. There is no per-seat SaaS pricing and no third party in the
-loop. Your media, and everything derived from it, stays on your instance.
+Being honest about the edges matters more than a blanket claim:
+
+- **Model downloads.** Models are not bundled in the image; they download on
+  first use from a configurable URL (by default, a public bucket run by the
+  project). You can mirror the models and point the URLs at your own host.
+  After download, inference is entirely local.
+- **Map tiles.** The map view loads tiles from OpenStreetMap by default.
+  Self-host tiles and set `PUBLIC_MAP_TILE_URL` if you don't want that.
+- **Error reporting (optional, off by default).** Operators can set a Sentry
+  DSN to collect crash reports on a service they choose. If unset, nothing is
+  reported anywhere.
+- **Public share links.** A shared moment is reachable by anyone with the
+  link — that's the point — and the share page includes preview images for
+  link embeds. Sharing is per-item, deliberate, and revocable.
+
+There is no analytics, no usage tracking, and your media is never uploaded
+anywhere for processing.
 
 ## The owner is in control
 
-Sensitive surfaces are **owner-gated**: the admin panel, the job-queue
-dashboard, registration policy, and runtime ML-model selection are reachable
-only by the instance owner. Sharing is opt-in per library and revocable.
+Sensitive surfaces are gated to the instance **owner**: the admin panel, the
+job-queue dashboard, the registration policy (open / invite-only / closed),
+and ML model selection. Within a library, owner / admin / viewer roles decide
+who can change what.
 
-## Degrade gracefully
+## Optional by nature
 
-Optional dependencies are exactly that — optional. The product stays usable when
-one is missing:
-
-- **No models?** Serve the originals.
-- **No Redis/queue?** Inline-process transforms instead of enqueuing them.
-- **Slow WebSocket client?** Drop the frame and let it re-fetch on reconnect.
-
-:::tip
-Because ML is async and optional, you can run a minimal Alcoves instance with no
-ML at all, then enable detection later by selecting models in the admin panel —
-existing media gets processed by the queue in the background.
-:::
+Media analysis is asynchronous and optional. Files are usable the moment they
+upload; faces, labels, and transcripts fill in as jobs finish. Face and object
+detection can be toggled per library, and if a model hasn't downloaded yet,
+Alcoves simply serves your files and catches up on analysis later.

--- a/website/src/content/docs/features/search-activity-notifications.md
+++ b/website/src/content/docs/features/search-activity-notifications.md
@@ -1,6 +1,6 @@
 ---
 title: "Search, activity feed & notifications"
-description: "Find files across libraries with AI-powered search, track library history in the activity feed, and get real-time notifications from collaborators."
+description: "Search across all your libraries by name, detected content, and transcripts; follow library history in the activity feed; get real-time notifications from collaborators."
 ---
 
 Alcoves gives you three ways to stay on top of your media: a cross-library search that understands what is *in* your files, a per-library activity history, and a real-time notification bell for collaborator actions.

--- a/website/src/content/docs/getting-started/configuration.md
+++ b/website/src/content/docs/getting-started/configuration.md
@@ -12,7 +12,7 @@ in the repository is the complete, always-current list.
 
 | Variable                 | Description                                                                  |
 | ------------------------ | ---------------------------------------------------------------------------- |
-| `ALCOVES_SESSION_SECRET` | Key for encrypted session cookies. **At least 32 bytes** — the API refuses to start without it. |
+| `ALCOVES_SESSION_SECRET` | Key for encrypted session cookies. Required — the API won't start without it. It's hashed into the encryption key, so any non-empty value works, but use a long random one (below). |
 | `ALCOVES_DATABASE_URL`   | PostgreSQL connection string. The database needs the pgvector extension.      |
 
 Generate a session secret with:
@@ -51,7 +51,7 @@ background pipeline independently — see
 | Variable                      | Default        | Description                                |
 | ----------------------------- | -------------- | ------------------------------------------ |
 | `ALCOVES_STORAGE_DRIVER`      | `local`        | Storage backend.                           |
-| `ALCOVES_STORAGE_PATH`        | `./data`       | Root path for uploaded files.              |
+| `ALCOVES_STORAGE_PATH`        | `./data`       | Base data directory. Uploaded files live under `{path}/files`. |
 | `ALCOVES_AVATAR_STORAGE_PATH` | `{path}/avatars` | Override path for avatars.               |
 | `ALCOVES_CACHE_STORAGE_PATH`  | `{path}/.cache`  | Override path for derived media (thumbnails, transcodes). |
 

--- a/website/src/content/docs/getting-started/configuration.md
+++ b/website/src/content/docs/getting-started/configuration.md
@@ -3,79 +3,92 @@ title: Configuration
 description: The ALCOVES_* environment variables that configure runtime mode, database, storage, sessions, and OAuth.
 ---
 
-Alcoves is configured entirely through environment variables, all prefixed with
-`ALCOVES_` so they nest cleanly into container environments. Copy
-[`.env.example`](https://github.com/rustyguts/alcoves/blob/main/.env.example) to
-`.env` and fill in your values.
+Alcoves is configured through environment variables, prefixed with `ALCOVES_`
+on the backend. This page covers the ones most installs touch;
+[`.env.example`](https://github.com/rustyguts/alcoves/blob/main/.env.example)
+in the repository is the complete, always-current list.
 
-:::note[Sample doc]
-This page covers the most common variables. See `.env.example` in the repo for
-the complete, authoritative list.
+## Required
+
+| Variable                 | Description                                                                  |
+| ------------------------ | ---------------------------------------------------------------------------- |
+| `ALCOVES_SESSION_SECRET` | Key for encrypted session cookies. **At least 32 bytes** — the API refuses to start without it. |
+| `ALCOVES_DATABASE_URL`   | PostgreSQL connection string. The database needs the pgvector extension.      |
+
+Generate a session secret with:
+
+```sh
+openssl rand -base64 48
+```
+
+:::caution
+Rotating the session secret signs everyone out. Never reuse an example value
+in production.
 :::
 
 ## Runtime
 
-| Variable           | Default                 | Description                                                            |
-| ------------------ | ----------------------- | ---------------------------------------------------------------------- |
-| `ALCOVES_MODE`     | `all`                   | Capabilities to run: `all`, `api` (web only), or `worker` (jobs only). |
-| `ALCOVES_ENV`      | `development`           | Environment name: `development` or `production`.                       |
-| `ALCOVES_BASE_URL` | `http://localhost:5173` | Public base URL — used for OAuth redirects and share links.            |
+| Variable           | Default                 | Description                                                              |
+| ------------------ | ----------------------- | ------------------------------------------------------------------------ |
+| `ALCOVES_MODE`     | `all`                   | `all` (API + worker), `api` (HTTP only), or `worker` (background jobs only). |
+| `ALCOVES_ENV`      | `development`           | Set `production` for real deployments — `development` relaxes CORS for localhost. |
+| `ALCOVES_BASE_URL` | `http://localhost:3000` | The public URL of the instance. Drives OAuth redirects, share links, and CORS. Keep it accurate. |
 
 Splitting `api` and `worker` lets you scale the request path and the heavy
-async pipeline independently.
+background pipeline independently — see
+[deploying Alcoves](/self-hosting/deploying-alcoves/).
 
-## Database & queue
+## Queue
 
-| Variable                | Default                          | Description                                |
-| ----------------------- | -------------------------------- | ------------------------------------------ |
-| `ALCOVES_DATABASE_URL`  | `postgres://…@localhost:5455/…`  | PostgreSQL connection string.              |
-| `ALCOVES_QUEUE_HOST`    | `localhost`                      | Dragonfly/Redis host for the Asynq queue.  |
-| `ALCOVES_QUEUE_PORT`    | `6389`                           | Dragonfly/Redis port.                      |
-| `ALCOVES_QUEUE_PASSWORD`| _(empty)_                        | Optional queue password.                   |
-
-## Session
-
-| Variable                 | Description                                                            |
-| ------------------------ | --------------------------------------------------------------------- |
-| `ALCOVES_SESSION_SECRET` | AES-GCM key for encrypted session cookies. **Must be ≥ 32 bytes.**    |
-
-Generate one with:
-
-```sh
-openssl rand -base64 32
-```
-
-:::caution
-Never ship the example secret to production. Sessions are encrypted with this
-key — rotating it invalidates every existing session.
-:::
+| Variable                 | Default     | Description                               |
+| ------------------------ | ----------- | ----------------------------------------- |
+| `ALCOVES_QUEUE_HOST`     | `localhost` | Dragonfly/Redis host for background jobs. |
+| `ALCOVES_QUEUE_PORT`     | `6389`      | Port (most Redis setups use `6379`).      |
+| `ALCOVES_QUEUE_PASSWORD` | _(empty)_   | Optional queue password.                  |
 
 ## Storage
 
-| Variable                       | Default   | Description                              |
-| ------------------------------ | --------- | ---------------------------------------- |
-| `ALCOVES_STORAGE_DRIVER`       | `local`   | Storage backend: `local` or `s3`.        |
-| `ALCOVES_STORAGE_PATH`         | `./data`  | Local blob path (when driver is `local`).|
-| `ALCOVES_AVATAR_STORAGE_PATH`  | _(empty)_ | Override path for avatars.               |
-| `ALCOVES_CACHE_STORAGE_PATH`   | _(empty)_ | Override path for the derived cache.     |
+| Variable                      | Default        | Description                                |
+| ----------------------------- | -------------- | ------------------------------------------ |
+| `ALCOVES_STORAGE_DRIVER`      | `local`        | Storage backend.                           |
+| `ALCOVES_STORAGE_PATH`        | `./data`       | Root path for uploaded files.              |
+| `ALCOVES_AVATAR_STORAGE_PATH` | `{path}/avatars` | Override path for avatars.               |
+| `ALCOVES_CACHE_STORAGE_PATH`  | `{path}/.cache`  | Override path for derived media (thumbnails, transcodes). |
 
-For S3-compatible object storage, set `ALCOVES_S3_BUCKET`, `ALCOVES_S3_REGION`,
-`ALCOVES_S3_ENDPOINT`, `ALCOVES_S3_ACCESS_KEY_ID`, and
-`ALCOVES_S3_SECRET_ACCESS_KEY`.
+:::note
+`ALCOVES_S3_*` variables exist and parse, but the S3 driver is **not wired up
+yet** — the server currently always uses local storage. Treat S3 as planned,
+not available.
+:::
 
-## Google OAuth (optional)
+## Google login (optional)
 
-| Variable                            | Description                          |
-| ----------------------------------- | ------------------------------------ |
-| `ALCOVES_OAUTH_GOOGLE_CLIENT_ID`    | Google OAuth client ID.              |
-| `ALCOVES_OAUTH_GOOGLE_CLIENT_SECRET`| Google OAuth client secret.          |
+| Variable                             | Description                 |
+| ------------------------------------ | --------------------------- |
+| `ALCOVES_OAUTH_GOOGLE_CLIENT_ID`     | Google OAuth client ID.     |
+| `ALCOVES_OAUTH_GOOGLE_CLIENT_SECRET` | Google OAuth client secret. |
 
-The frontend fetches available providers from the API at runtime, so OAuth
-buttons appear automatically once these are set.
+Also set `PUBLIC_GOOGLE_AUTH_ENABLED=true` on the frontend so the sign-in
+button shows up (the Helm chart does this automatically).
 
 ## Frontend
 
-| Variable                    | Default                 | Description                                                  |
-| --------------------------- | ----------------------- | ----------------------------------------------------------- |
-| `ALCOVES_API_URL`           | `http://localhost:3001` | Go backend URL for the Nitro dev proxy and SSR fetches.     |
-| `NITRO_HOST` / `NITRO_PORT` | `:3000`                 | Override the frontend server bind address.                  |
+The SvelteKit server reads its own variables (not `ALCOVES_`-prefixed):
+
+| Variable                      | Default                 | Description                                                                  |
+| ----------------------------- | ----------------------- | ----------------------------------------------------------------------------- |
+| `INTERNAL_API_URL`            | `http://localhost:3001` | Where the SvelteKit server reaches the Go API for SSR and the `/api` proxy.   |
+| `PUBLIC_API_ORIGIN`           | _(empty)_               | When set, browsers stream video/images/downloads and the activity WebSocket directly from the API instead of through the SvelteKit proxy. Recommended in production. |
+| `FRONTEND_HOST` / `FRONTEND_PORT` | `0.0.0.0` / `3000`  | Bind address of the SvelteKit server.                                         |
+| `FRONTEND_BODY_SIZE_LIMIT`    | `Infinity`              | Keep unbounded, or large upload chunks through the proxy are rejected.        |
+| `PUBLIC_GOOGLE_AUTH_ENABLED`  | _(empty)_               | `true` shows the Google sign-in button.                                       |
+| `PUBLIC_MAP_TILE_URL` / `PUBLIC_MAP_TILE_ATTRIBUTION` | OpenStreetMap | Point the map view at self-hosted tiles if you prefer.    |
+
+## Optional features
+
+| Variable                   | Default | Description                                                       |
+| -------------------------- | ------- | ------------------------------------------------------------------ |
+| `ALCOVES_MCP_HTTP_ENABLED` | `false` | Serve the [MCP server](/features/mcp-server/) over HTTP at `/api/mcp`. |
+| `ALCOVES_MCP_OAUTH_ENABLED`| `false` | OAuth 2.1 flow for remote MCP connectors (requires the HTTP transport and an `https` base URL). |
+| `ALCOVES_SENTRY_DSN`       | _(empty)_ | Backend error reporting to a Sentry instance you choose. Off unless set. |
+| `ALCOVES_WHISPER_MODEL`    | `large-v3` | Boot-time default transcription model; admins can change it at runtime in the admin panel. |

--- a/website/src/content/docs/getting-started/quickstart.md
+++ b/website/src/content/docs/getting-started/quickstart.md
@@ -1,97 +1,122 @@
 ---
 title: Quickstart
-description: Get a full Alcoves stack — frontend, API, Postgres, and the job queue — running locally with Docker Compose.
+description: Run Alcoves with Docker Compose — the published image plus PostgreSQL and a job queue.
 ---
 
-This guide gets a complete Alcoves instance running locally: the Nuxt frontend,
-the Go API + worker, PostgreSQL, and Dragonfly (a Redis-compatible queue).
-
-:::note[Sample doc]
-This is a starter quickstart. Commands mirror the repo's
-[deployment & operations](https://github.com/rustyguts/alcoves/blob/main/docs/deployment-and-operations.md)
-guide — check there for the authoritative, full reference.
-:::
+The fastest way to run Alcoves is Docker Compose: the published all-in-one
+image, PostgreSQL (with pgvector), and Dragonfly (a Redis-compatible queue for
+background jobs).
 
 ## Prerequisites
 
-- **Docker** and **Docker Compose** (v2)
-- ~8 GB of free RAM (the CPU-only ML models are the ceiling)
-- Git
+- **Docker** with **Docker Compose** (v2)
+- An x86_64 machine. 8 GB of RAM is comfortable; the biggest consumer is
+  transcription, and you can pick a smaller whisper model in the admin panel
+  if memory is tight. No GPU is needed.
 
-## 1. Clone and configure
+## 1. Create a compose file
+
+Save this as `docker-compose.yml` in an empty directory:
+
+```yaml
+services:
+  alcoves:
+    image: ghcr.io/rustyguts/alcoves:0.28.0 # pin to the latest release
+    ports:
+      - '3000:3000'
+    environment:
+      - ALCOVES_BASE_URL=http://localhost:3000
+      - ALCOVES_SESSION_SECRET=${ALCOVES_SESSION_SECRET:?set in .env}
+      - ALCOVES_DATABASE_URL=postgres://postgres:postgres@postgres:5432/alcoves
+      - ALCOVES_QUEUE_HOST=dragonfly
+      - ALCOVES_QUEUE_PORT=6379
+    volumes:
+      - alcoves_data:/app/data
+    depends_on:
+      - postgres
+      - dragonfly
+    restart: unless-stopped
+
+  postgres:
+    image: pgvector/pgvector:pg18
+    environment:
+      - POSTGRES_DB=alcoves
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    restart: unless-stopped
+
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    restart: unless-stopped
+
+volumes:
+  alcoves_data:
+  postgres_data:
+```
+
+Then generate a session secret (used to encrypt login cookies) into a `.env`
+file next to it:
+
+```sh
+echo "ALCOVES_SESSION_SECRET=$(openssl rand -base64 48)" > .env
+```
+
+## 2. Start it
+
+```sh
+docker compose up -d
+```
+
+The one Alcoves container runs the whole stack: the web UI, the Go API, and
+the background worker. Database migrations apply automatically on startup.
+Check it's up:
+
+```sh
+curl http://localhost:3000/api/health
+# {"mode":"all","status":"ok"}
+```
+
+## 3. Open the app
+
+Visit **http://localhost:3000** and register an account. The first account
+becomes the instance **owner** — the only role that can open the admin panel,
+the job-queue dashboard, registration policy, and ML model selection.
+
+Upload a few photos or a short video and watch the library fill in:
+thumbnails appear first, then faces, labels, and transcripts as the
+background jobs finish. Models download on first use, so the very first
+detection or transcription job takes longer than the rest.
+
+## Putting it on the internet
+
+The compose file above binds plain HTTP on one port, which is fine on your own
+machine. For a real deployment, put a reverse proxy with TLS in front, set
+`ALCOVES_BASE_URL` to the public URL, and set `ALCOVES_ENV=production`. The
+[deployment guide](/self-hosting/deploying-alcoves/) covers reverse-proxy
+settings (uploads and video streaming need a couple of specific ones), the
+Helm chart for Kubernetes, and the rest of the operational details.
+
+## Hacking on Alcoves instead?
+
+The repository's own `docker-compose.yml` runs the **development** stack — hot
+reload for both the Go backend and the SvelteKit frontend, plus seeded demo
+data (sample users, libraries, photos, transcripts) so every feature has
+something to show:
 
 ```sh
 git clone https://github.com/rustyguts/alcoves.git
 cd alcoves
-cp .env.example .env
-```
-
-Open `.env` and set a real session secret before anything else:
-
-```sh
-# Generate an AES-GCM key (must be ≥ 32 bytes)
-openssl rand -base64 32
-```
-
-Paste the result into `ALCOVES_SESSION_SECRET`.
-
-## 2. Start the stack
-
-```sh
 docker compose up
 ```
 
-This brings up four services:
-
-| Service     | Host port  | Purpose                                                         |
-| ----------- | ---------- | -------------------------------------------------------------- |
-| Frontend    | `3000`     | Nuxt (Nitro) server — open this in your browser                |
-| Backend API | `3001`     | Go API + worker (`ALCOVES_MODE=all`)                           |
-| Dragonfly   | `6389`     | Redis-compatible async job queue (Asynq)                       |
-| PostgreSQL  | _internal_ | Primary database; reachable in-network at `postgres:5432` only |
-
-:::note
-PostgreSQL is **not** published to the host by the default `docker-compose.yml` —
-it's only reachable from the other containers (at `postgres:5432`). If you want to
-connect from your machine, add a `ports:` mapping to the `postgres` service.
-:::
-
-Goose migrations run automatically on startup, so the schema is ready the first
-time the API boots.
-
-## 3. Open the app
-
-Visit **http://localhost:3000** and register the first account. The first user
-becomes the instance **owner** — the only role that can reach the admin panel,
-the job queue dashboard, registration policy, and ML-model selection.
-
-:::tip
-The AI features (faces, objects, audio events, transcription) run **asynchronously**.
-Upload a few photos or a short video, then watch the job queue in the admin
-panel work through detection — no GPU required.
-:::
-
-## 4. Infrastructure only (optional)
-
-To run Postgres and Dragonfly in Docker but the apps from source:
-
-```sh
-docker compose up -d postgres dragonfly
-```
-
-Then start each side from its own directory:
-
-```sh
-# Backend (from backend/)
-go run cmd/server/main.go
-
-# Frontend (from frontend/)
-bun install
-bun run dev
-```
+Then log in at http://localhost:3000 as `test@alcoves.io` / `password123`
+(the seeded owner account — the demo data means you do *not* register a first
+account here).
 
 ## Next steps
 
-- [Configuration](/getting-started/configuration/) — every `ALCOVES_*` knob.
-- [Architecture overview](/architecture/overview/) — how the pieces fit together.
-- [Privacy & local AI](/concepts/privacy-and-local-ai/) — how inference stays on your box.
+- [Configuration](/getting-started/configuration/) — the environment variables that matter.
+- [Deploying Alcoves](/self-hosting/deploying-alcoves/) — production setups, Helm, operations.
+- [Privacy & local AI](/concepts/privacy-and-local-ai/) — what runs locally and what doesn't.

--- a/website/src/content/docs/overview.mdx
+++ b/website/src/content/docs/overview.mdx
@@ -1,92 +1,96 @@
 ---
 title: Overview
-description: What Alcoves is — a self-hosted, privacy-first collaborative media library with AI that runs locally on hardware you own.
+description: What Alcoves is — a self-hosted file and media library for individuals and small trusted groups.
 ---
 
-import { Card, CardGrid, LinkCard, Aside } from '@astrojs/starlight/components';
+import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-**Alcoves** is a self-hosted, privacy-first collaborative media library — a
-Google Drive plus Google Photos replacement you run yourself. It stores your
-photos, videos, audio, and documents; it _understands_ them (faces, objects,
-sounds, speech); it lets a small group browse, organize, and share them — and it
-does all of this on hardware you own, with **no telemetry, no per-seat pricing,
-and no third party in the loop**.
+**Alcoves** is a self-hosted application for keeping, organizing, and sharing
+your files, with particular care for photos, video, and audio. You run it on
+your own hardware: your files stay on your storage, the features that read
+your media run locally, and your library is never sent anywhere to be analyzed.
 
-<Aside type="note" title="These are starter docs">
-	This documentation site is new. The pages here are concise samples derived
-	from the project's in-repo docs and [vision](https://github.com/rustyguts/alcoves/blob/main/docs/vision.md);
-	they'll be expanded into the full reference over time.
-</Aside>
+It is built for individuals and small, trusted groups — a person keeping a
+lifetime of photos, a family sharing memories, a small team working on video
+together. It is not a public, internet-scale service, and it doesn't try to be.
 
-## Why Alcoves
+## What it does today
 
-The convenient tools for managing personal and family media are the ones that
-mine it. The tools that respect your privacy are usually too primitive to be
-worth using. Alcoves refuses that trade-off: it aims to be _as capable as the
-cloud incumbents on the features that matter, while being something you fully
-own_.
+- **Files and folders** — upload from the browser (resumable, so large videos
+  survive a flaky connection), organize into folders, tag, trash and restore.
+  Duplicate uploads are detected by content hash.
+- **Photos** — thumbnails and fast previews, a timeline view by capture date,
+  and a map view for photos with GPS data.
+- **People** — faces are detected and grouped into people you can name. This
+  runs on your own machine, like all media analysis in Alcoves.
+- **Objects and sounds** — photos get searchable labels for what's in them;
+  audio and video are tagged by what they contain (speech, music, and so on).
+- **Transcription** — speech in audio and video becomes readable, searchable
+  text via whisper.cpp. The admin picks the model size to match the hardware.
+- **Video editing** — a timeline editor for marking and exporting clips
+  ("moments"), with transcript and sound filters to find the parts that matter.
+- **Sharing** — group files into libraries and invite people with a role that
+  fits (owner, admin, viewer), or publish a single moment as a public link
+  with a proper preview embed.
+- **Search and activity** — search across all your libraries by file name,
+  detected content, and transcripts; follow changes in shared libraries
+  through the activity feed and notifications.
+- **Your own tools** — a built-in [MCP server](/features/mcp-server/) lets AI
+  assistants and scripts browse, upload, and organize your library.
 
-## The pillars
+Heavy work — transcoding, thumbnails, detection, transcription — runs in a
+background job queue, so the app stays responsive while your library fills in.
+
+## How it holds together
 
 <CardGrid>
-	<Card title="Own your media" icon="seti:db">
-		Local-disk or S3-compatible storage, your database, your queue. The Go
-		binary is a pure API — nothing phones home. A Raspberry Pi with a USB drive
-		and a rack with an object store are both first-class.
+	<Card title="Your hardware, your data" icon="seti:db">
+		Files live on your own storage. PostgreSQL is the database, a
+		Redis-compatible queue feeds the background workers, and the whole stack
+		ships as one Docker image.
 	</Card>
-	<Card title="Understand it locally" icon="seti:image">
-		An async pipeline does SHA-256 dedup, thumbnails, video proxies, waveforms,
-		and a full suite of **CPU-only ONNX ML** — faces, objects, audio events, and
-		speech transcription. Models download on demand. No GPU. No inference leaves
-		the box.
+	<Card title="Local, CPU-only analysis" icon="seti:image">
+		Face, object, and audio detection plus transcription all run on CPU on
+		your own machine. No GPU needed, no cloud inference APIs involved.
 	</Card>
-	<Card title="Collaborate with real roles" icon="seti:lock">
-		Libraries are the unit of sharing. Owner / admin / viewer roles, invite
-		links with caps and expiry, and a per-library access gate enforced in
-		middleware before any handler runs.
+	<Card title="Deliberate sharing" icon="seti:lock">
+		Libraries are the unit of sharing. Access is enforced per library with
+		owner / admin / viewer roles, and invites can be capped and expired.
 	</Card>
-	<Card title="Video is first-class" icon="seti:video">
-		A real timeline editor: zoomable waveform, draggable named "moments",
-		transcript search, audio-detection overlays, MP4 export, and public,
-		OG-embeddable share links.
+	<Card title="Open to your tools" icon="seti:plan">
+		What you can do in the app, an assistant or script can do through the MCP
+		server — over stdio or HTTP, with personal access tokens or OAuth.
 	</Card>
 </CardGrid>
 
-## Who it's for
+## Status
 
-- **Individuals** who want a private home for a lifetime of photos and video,
-  with real search and real organization.
-- **Families** sharing a library — grandparents, kids, events — with sensible
-  roles so not everyone is an admin.
-- **Small teams and creators** (1–100 users per instance) collaborating on
-  video: clipping, transcribing, tagging, and sharing highlights.
-- **Self-hosters and homelab operators** who want a clean Helm chart and Docker
-  images for the Postgres, the queue, and the GPU-less inference.
-
-Alcoves is explicitly _not_ built for the 100,000-user multi-tenant SaaS case.
-It optimizes for a trusted instance shared by a known, bounded group.
+Alcoves is **alpha** (`0.x`). It works, and it is used daily, but it is early:
+expect rough edges and breaking changes between releases (they ship with
+migrations and changelog entries). If that's fine with you, it's free to run
+and the [quickstart](/getting-started/quickstart/) takes a few minutes.
 
 ## Next steps
 
 <CardGrid>
 	<LinkCard
 		title="Quickstart"
-		description="Run the full stack locally with Docker Compose in a few minutes."
+		description="Run Alcoves with Docker Compose in a few minutes."
 		href="/getting-started/quickstart/"
 	/>
 	<LinkCard
 		title="Configuration"
-		description="The ALCOVES_* environment variables that drive every instance."
+		description="The environment variables that configure an instance."
 		href="/getting-started/configuration/"
 	/>
 	<LinkCard
 		title="Architecture"
-		description="How the Nuxt frontend and Go/Echo/GORM/Asynq backend fit together."
+		description="How the SvelteKit frontend and the Go backend fit together."
 		href="/architecture/overview/"
 	/>
 	<LinkCard
 		title="Privacy & local AI"
-		description="Why every model is CPU-only and how inference stays on your box."
+		description="What runs locally, and the few places bytes leave your machine."
 		href="/concepts/privacy-and-local-ai/"
 	/>
 </CardGrid>

--- a/website/src/content/docs/reference/faq.md
+++ b/website/src/content/docs/reference/faq.md
@@ -3,48 +3,51 @@ title: FAQ
 description: Common questions about hardware, privacy, GPUs, deployment, and what Alcoves is (and is not).
 ---
 
-:::note[Sample doc]
-A starter FAQ. Questions and answers will grow alongside the product.
-:::
-
 ## Do I need a GPU?
 
-**No.** All ML in Alcoves is CPU-only by design — face/object detection, audio
-tagging, and speech transcription all run on CPU. Models are selected for that
-constraint. See [Privacy & local AI](/concepts/privacy-and-local-ai/).
+**No.** All media analysis in Alcoves — face and object detection, audio
+tagging, speech transcription — runs on CPU by design. See
+[Privacy & local AI](/concepts/privacy-and-local-ai/).
 
 ## Is any of my data sent anywhere?
 
-**No.** There is no telemetry, no analytics, and no inference that leaves your
-instance. The Go backend is a pure API that never phones home.
+Your files and everything derived from them stay on your instance, and there
+is no analytics or usage tracking. The few outward connections are ones you
+control: ML models download on first use (mirrorable), the map view loads
+OpenStreetMap tiles by default (configurable), and error reporting only exists
+if you configure a Sentry DSN. The details are on the
+[privacy page](/concepts/privacy-and-local-ai/).
 
 ## What hardware do I need?
 
-A machine with roughly **8 GB of RAM** is the practical ceiling for the CPU-only
-models. Storage scales with your library — use a local disk or any S3-compatible
-object store. A Raspberry Pi with a USB drive and a rack with an object store are
-both supported.
+An x86_64 machine — the published Docker images are x86_64-only right now.
+8 GB of RAM is comfortable. Transcription is the biggest memory consumer: the
+default whisper model wants several GB, and the admin panel lets you choose a
+smaller one for lighter hardware. Storage is a local disk (or any volume you
+mount); size it for your library.
 
 ## How do I deploy it?
 
-With **Docker** and **Docker Compose** for a single host, or the **Helm chart**
-for Kubernetes. External PostgreSQL and Dragonfly/Redis are expected; storage is
-local or S3. Start with the [Quickstart](/getting-started/quickstart/).
+With **Docker Compose** on a single machine, or the **Helm chart** on
+Kubernetes. You bring PostgreSQL (with pgvector) and a Redis-compatible queue
+(Dragonfly works well); one published image runs the frontend, the API, and
+the worker. Start with the [Quickstart](/getting-started/quickstart/).
 
 ## Who can administer an instance?
 
-The first registered user becomes the **owner**. Owner-gated surfaces include the
-admin panel, the job-queue dashboard, registration policy, and ML-model
-selection. Within libraries, the roles are **owner / admin / viewer**.
+The first registered user becomes the instance **owner**. Only the owner can
+open the admin panel, the job-queue dashboard, registration policy, and ML
+model selection. Within libraries, the roles are **owner / admin / viewer**.
 
 ## Is it production-ready?
 
-Alcoves is **alpha** (`0.x.y`). Expect breaking changes — they ship with
-migrations and changelog entries. It targets bounded, trusted instances
-(1–100 users), not anonymous mass signup.
+Alcoves is **alpha** (`0.x`). It works and is used daily, but expect breaking
+changes between releases — they ship with migrations and changelog entries.
+It is built for bounded, trusted groups, not anonymous mass signup.
 
 ## Can other tools talk to it?
 
-Yes — Alcoves ships an **MCP (Model Context Protocol) server** so MCP-capable
-clients can browse libraries and move files over stdio or HTTP, authenticated by
-a personal access token.
+Yes — Alcoves includes an **MCP (Model Context Protocol) server**, so
+MCP-capable assistants and scripts can browse libraries, upload, and organize
+files. It runs over stdio or HTTP, authenticated with a personal access token
+or OAuth. See the [MCP server](/features/mcp-server/) page.


### PR DESCRIPTION
## What

An accuracy-and-honesty pass over the website. The goal: every claim on the site is true of the code as it is today, stated plainly, with no overstatement.

### Claims removed or corrected

| Was | Now |
|---|---|
| "a Google Drive plus Google Photos replacement", "as capable as the cloud incumbents" | a plain description of what Alcoves does, plus an explicit alpha status section |
| "A Raspberry Pi with a USB drive … both first-class/supported" | x86_64-only (the published images are amd64; whisper.cpp is built for x86-64-v3) |
| "local-disk or S3-compatible storage", "Both [drivers] are wired at startup" | S3 config parses but the server always uses the local driver — marked planned, not available (matches the repo's Known Gaps) |
| "Small teams and creators (1–100 users per instance)" | small, trusted groups — no invented numbers |
| "No telemetry, ever" / "Is any data sent anywhere? **No.**" | the honest version: model downloads (mirrorable), default OpenStreetMap map tiles (configurable), opt-in Sentry. No analytics or media upload, stated without absolutism |
| "No Redis/queue? Inline-process transforms" | dropped (unverifiable); degradation claims limited to what's true (files usable immediately, analysis fills in, per-library detection toggles) |
| "AI-powered search" (page description) | search by name, detected content, and transcripts |
| "practical ceiling is roughly 8 GB" | 8 GB comfortable; transcription is the big consumer and the model size is admin-selectable |

### Stale Nuxt-era content replaced

- **Quickstart** was the old Nuxt dev guide — and told users to "register the first account" against the repo dev stack, which seeds demo users (the owner is `test@alcoves.io`, so registering there doesn't make you owner). It now leads with a minimal self-host compose file for the published image, **tested end-to-end against `ghcr.io/rustyguts/alcoves:0.28.0`** (`/api/health` ok, login page 200, `/api/version` 0.28.0; PG18 volume mount path verified), and keeps the dev stack as a separate "hacking on Alcoves" path with the seeded login.
- **Configuration**: wrong `ALCOVES_BASE_URL` default fixed; `ALCOVES_API_URL`/`NITRO_*` replaced with the real `INTERNAL_API_URL`/`PUBLIC_API_ORIGIN`/`FRONTEND_*`; corrected the claim that OAuth buttons appear automatically (the frontend reads `PUBLIC_GOOGLE_AUTH_ENABLED`); short optional-features table (MCP, Sentry, whisper model).
- **Architecture overview**: SvelteKit topology, default-SSR (the "SSR is scoped to /s/**, all other routes are client-rendered" claim was wrong), corrected proxy routing (`/s/**` is SvelteKit, not Go).
- **Backend architecture**: remaining Nuxt mentions and the local-or-S3 claim fixed.
- All "Sample doc" asides removed along with their links to repo docs that no longer exist (`docs/deployment-and-operations.md`, `docs/ml-models-and-runtime-inference.md`, `docs/models.md`).

### Landing page

Copy was already plain; only change is the hardware FAQ answer ("comfortably on modest hardware" → "No GPU is needed — a few CPU cores and 8 GB of RAM is plenty to start").

### Out of scope

`self-hosting/deploying-alcoves.md` is untouched here — it's being rewritten in #625 with the Helm chart.

## Validation

- Quickstart compose verified against the real published image (see above).
- Facts cross-checked against the code: first-user-becomes-owner (`handlers/auth.go`), `PUBLIC_GOOGLE_AUTH_ENABLED` (`login/+page.svelte`), cookie `Secure` behavior, S3 known gap, image build arch, seed gating.
- `astro build` and `astro check` green (25 pages, 0 errors/warnings).